### PR TITLE
Refactor - Drop EOL Python versions, use types, f-strings, tabs, single quotes, Ruff linter, pyproject.toml, ...

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: v2m-ci
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -17,25 +17,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10, 3.11, 3.12]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        python -m pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          python -m pytest

--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ sudo apt install python-opencv python-pygame python-midiutil python-opengl
 #### Arch Linux:
 ```bash
 sudo pacman -S hdf5 python-opencv python-pygame python-opengl
-sudo pip install midiutil
+# Venv
+pip install midiutil
 ```
 Or thanks to C0rn3j you can install video2midi just from AUR now using your favorite AUR helper:
-```
+```bash
 yay -S video2midi-git
 ```
 
-#### Windows + Anaconda2 (python 2.7)/Anaconda3 (python 3.7):
+#### Windows + Anaconda (python 3.9+):
  - [Read this instruction to using video2midi from github on Windows](https://github.com/svsdval/video2midi/wiki/Using-video2midi-from-github-on-Windows)
 
 # usage
@@ -54,7 +55,7 @@ yay -S video2midi-git
   ./v2m.py ./synthesia_video.mkv
   ```
 
-##### Windows+Anaconda2 (python 2.7)/Anaconda3 (python 3.7):
+##### Windows + Anaconda (python 3.9+):
  in start menu search and open Anaconda command prompt:
   ```bash
   cd path to v2m.py
@@ -83,7 +84,7 @@ yay -S video2midi-git
   * **Escape** - quit
   * **Space** - abort re-creation and save midi file to disk
 
-  
+
 # how it works
 
 Frame by frame we scan the virtual keyboard and write the keys to the midi file...
@@ -109,8 +110,7 @@ You can customize the channel mapping to a MIDI instrument. To do this, in the v
 The default all channels is 0 midi instrument.
 
 ```python
-channel_prog_accordance = 0,0, 0,0, 0,0, 0,0, 0,0, 0,0 
-
+channel_prog_accordance = 0,0, 0,0, 0,0, 0,0, 0,0, 0,0
 ```
 
 # RU:
@@ -132,10 +132,11 @@ sudo apt install python-opencv python-pygame python-midiutil python-opengl
 #### Arch Linux:
 ```bash
 sudo pacman -S hdf5 python-opencv python-pygame python-opengl
-sudo pip install midiutil
+# Venv
+pip install midiutil
 ```
 
-#### Windows + Anaconda2 (python 2.7)/Anaconda3 (python 3.7):
+#### Windows + Anaconda (python 3.9+):
  - [Читаем эту инструкцию что бы юзать video2midi под Windows](https://github.com/svsdval/video2midi/wiki/Using-video2midi-from-github-on-Windows)
 
 ## использование
@@ -147,7 +148,7 @@ sudo pip install midiutil
   ./v2m.py ./synthesia_video.mkv
   ```
 
-##### Windows+Anaconda2 (python 2.7)/Anaconda3 (python 3.7):
+##### Windows + Anaconda (python 3.9+):
  in start menu search and open Anaconda command prompt:
   ```bash
   cd path to v2m.py
@@ -166,16 +167,16 @@ sudo pip install midiutil
   * **Mouse wheel** - подстройка клавиш
   * **Левая кнопка мыши** - перетаскивание выбранной клавиши / выбор цвета из карты цветов.
   * **CTRL + Левая кнопка мыши** - обновить выбранный цвет к карте цветов.
-  * **Правая кнопка мыши** - перетаскивание всех клавиш, если клавиша выбрана, перенос осуществляется относительно неё 
+  * **Правая кнопка мыши** - перетаскивание всех клавиш, если клавиша выбрана, перенос осуществляется относительно неё
   * **CTRL + 0** - Выключить выбранный цвет.
-  * **Стрелки** - подстройка клавиш  (модификатор: shift)
+  * **Стрелки** - подстройка клавиш (модификатор: shift)
   * **PageUp/PageDown** - прокрутка видео (модификатор: shift, шаг по кадру)
   * **Home/End** - переход в начало или конец видео
   * **[ / ]** - изменить базовую октаву
   * **F2/F3** - записать / загрузить настройки.
   * **ESCAPE** - выход / quit
   * **SPACE** - прервать воссоздание и записать midi файл на диск / abort re-creation and save midi file to disk
-  
+
 ## как это работает
 
 Кадр за кадром сканируется видео поток отслеживая изменения виртуальной клавиатуры после всё что зафиксировано дампим на винт.
@@ -186,7 +187,7 @@ sudo pip install midiutil
 
 Все настройки вынесены в файл ini файл который может использоваться как общий для всех каталогов если находится в домашнем каталоге ~/.v2m.ini либо отдельный локальный для каталога ./v2m.ini.
 
-Вы можете настроить разбиение на каналы в зависимости от цвета клавиши. Для этого в файле v2m.ini нужно поправить соответствие цвета каналу midi трека. 
+Вы можете настроить разбиение на каналы в зависимости от цвета клавиши. Для этого в файле v2m.ini нужно поправить соответствие цвета каналу midi трека.
 По умолчанию каждый цвет активирующий клавишу будет записан в собственный канал, таким образом если хотите объединить каналы просто укажите для разных цветов одинаковые номера.
 
 ```python
@@ -195,10 +196,9 @@ color_channel_accordance = 0,0, 1,1, 2,2, 3,3, 4,4, 5,5
 
 ![Alt text](docs/multichannel.png?raw=true "multi channel midi export")
 
-Вы можете настроить соотнесение канала к MIDI инструменту. Для этого в файле v2m.ini нужно поправить соответствие канала midi инструменту. 
+Вы можете настроить соотнесение канала к MIDI инструменту. Для этого в файле v2m.ini нужно поправить соответствие канала midi инструменту.
 По умолчанию канал равен 0 midi инструменту
 
 ```python
-channel_prog_accordance = 0,0, 0,0, 0,0, 0,0, 0,0, 0,0 
-
+channel_prog_accordance = 0,0, 0,0, 0,0, 0,0, 0,0, 0,0
 ```

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ youtube synthesia video to midi, just for fun )
 GH already added new [discuss functionality](https://github.com/svsdval/video2midi/discussions) so we can talk without opening an issue... if you have any questions or comments, [you can open discuss](https://github.com/svsdval/video2midi/discussions) or you can write to [whatsapp](https://api.whatsapp.com/send/?phone=79635368469&text&app_absent=0) / [telegram](https://t.me/svsd_val) , i'll try to answer / help  ;)
 
 # EN:
-# dependency
+# Dependencies
 
 - python-opengl
 - python-opencv
 - python-pygame
 - python-midiutil
 
-# install dependency
+# Install dependencies
 
 #### Debian based Linux:
 ```bash
@@ -43,26 +43,26 @@ Or thanks to C0rn3j you can install video2midi just from AUR now using your favo
 yay -S video2midi-git
 ```
 
-#### Windows + Anaconda (python 3.9+):
- - [Read this instruction to using video2midi from github on Windows](https://github.com/svsdval/video2midi/wiki/Using-video2midi-from-github-on-Windows)
+#### Windows + Anaconda (Python 3.9+):
+- [Read these instructions to use video2midi from GitHub on Windows](https://github.com/svsdval/video2midi/wiki/Using-video2midi-from-github-on-Windows)
 
-# usage
+# Usage
 
- Download the video with your favorite melody (I recommend 720p), launch the program, adjust the keys in it, press Q and after the completion of the work a midi file will be created.
+Download the video with your favorite melody (I recommend 720p), launch the program, adjust the keys in it, press Q and after the processing completes a MIDI file will be created.
 
 ##### GNU/Linux:
-  ```bash
-  ./v2m.py ./synthesia_video.mkv
-  ```
+```bash
+./v2m.py ./synthesia_video.mkv
+```
 
-##### Windows + Anaconda (python 3.9+):
- in start menu search and open Anaconda command prompt:
+##### Windows + Anaconda (Python 3.9+):
+  In the Start menu, search for and open Anaconda command prompt:
   ```bash
   cd path to v2m.py
   python v2m.py synthesia_video.mkv
   ```
 
-  Control:
+  Controls:
   * **h** - show/hide this help
   * **q** - begin to recreate midi
   * **s** - set start frame, (mods : shift, set processing start frame to the beginning)
@@ -85,24 +85,22 @@ yay -S video2midi-git
   * **Space** - abort re-creation and save midi file to disk
 
 
-# how it works
+# How it works
 
-Frame by frame we scan the virtual keyboard and write the keys to the midi file...
+We scan the virtual keyboard, frame by frame, and write the keys to a MIDI file...
 
 ![Alt text](docs/frame47.jpg?raw=true "input from image")
 
 # Additional features
 
+All settings are loaded from an INI file, a global one can be defined in the home directory (`~/.v2m.ini`) or you can define a separate local one in the current directory (`./v2m.ini`).
 
-All settings are moved to an ini file which can be used as common for all directories if it is located in the home directory (~/.v2m.ini) or as a separate for local directory (./v2m.ini).
-
-You can also customize the separation into channels depending on the color of the key. To do this, in the v2m.ini file, you need to modify the color matching to the midi channel of the track.
-By default, each color key will be recorded in its own channel, so if you want to combine the channels, simply specify the same numbers for different colors.
+You can also customize the separation into channels depending on the color of the key. To do this, you need to modify the color matching to the midi channel of the track in the `v2m.ini` file.
+By default, each key color will be recorded in its own channel, so if you want to combine the channels, simply specify the same numbers for different colors.
 
 ```python
 color_channel_accordance = 0,0, 1,1, 2,2, 3,3, 4,4, 5,5
 ```
-
 
 ![Alt text](docs/multichannel.png?raw=true "multi channel midi export")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+requires-python = '>=3.9'
+[tool.ruff]
+# Target non-EOL releases at minimum, or later if needed
+# https://devguide.python.org/versions/
+target-version = 'py39'
+# Do soft 80, and hard break at 120
+line-length = 120
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = 'single'
+
+[tool.ruff.format]
+quote-style = 'single'
+indent-style = 'tab'
+
+[tool.ruff.lint]
+select = ['ALL']
+ignore = [
+	'W191',   # We use tabs for indents, disabling this atrocious PEP 8 recommendation
+	'D206',   # ^
+	'D401',   # non-imperative-mood - Wants docstrings in imperative language but it's really not foolproof, disable
+	'ERA001', # Test for commented out code, but it has way too many false positives, so disable
+	'FBT001', # boolean-type-hint-positional-argument     - Allow positional booleans in functions, it's not really that much of an issue
+	'FBT002', # boolean-default-value-positional-argument - ^
+	'FBT003', # boolean-positional-value-in-call          - ^
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires-python = '>=3.9'
 # Target non-EOL releases at minimum, or later if needed
 # https://devguide.python.org/versions/
 target-version = 'py39'
-# Do soft 80, and hard break at 120
-line-length = 120
+# Ideally do soft 80, and hard break at 127 as that's the GitHub editor length
+line-length = 127
 
 [tool.ruff.lint.flake8-quotes]
 # Note that CI runs some flake8 tests itself

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ target-version = 'py39'
 line-length = 120
 
 [tool.ruff.lint.flake8-quotes]
+# Note that CI runs some flake8 tests itself
 inline-quotes = 'single'
 multiline-quotes = 'single'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ line-length = 120
 
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = 'single'
+multiline-quotes = 'single'
 
 [tool.ruff.format]
 quote-style = 'single'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,34 +1,35 @@
-import unittest
 import tempfile
+import unittest
 
-from video2midi.settings import *
 from video2midi.prefs import prefs
+from video2midi.settings import *
+
 
 class TestMySettings(unittest.TestCase):
 
-    def test_a_settings_load(self):
-        self.assertEqual(prefs.xoffset_whitekeys, 60)
-        loadsettings('./tests/spin.mp4.ini')
-        self.assertEqual(prefs.xoffset_whitekeys, 99)
+	def test_a_settings_load(self) -> None:
+		self.assertEqual(prefs.xoffset_whitekeys, 60)
+		loadsettings('./tests/spin.mp4.ini')
+		self.assertEqual(prefs.xoffset_whitekeys, 99)
 
-    def test_b_persist_octave(self):
-        ini = tempfile.NamedTemporaryFile(suffix='.ini').name
-        prefs.octave = 2
-        savesettings(ini)
-        prefs.octave = 3
-        loadsettings(ini)
-        self.assertEqual(prefs.octave, 2)
+	def test_b_persist_octave(self) -> None:
+		ini = tempfile.NamedTemporaryFile(suffix='.ini').name
+		prefs.octave = 2
+		savesettings(ini)
+		prefs.octave = 3
+		loadsettings(ini)
+		self.assertEqual(prefs.octave, 2)
 
-    def test_c_compatible_size(self):
-        loadsettings('./tests/spin.mp4.ini')
-        self.assertEqual(len(prefs.keyp_colors_channel_prog),14);
+	def test_c_compatible_size(self) -> None:
+		loadsettings('./tests/spin.mp4.ini')
+		self.assertEqual(len(prefs.keyp_colors_channel_prog),14);
 
-        colorBtns = []
-        for i in range(22):
-            colorBtns.append( [0,0,0] )
+		colorBtns = []
+		for i in range(22):
+			colorBtns.append( [0,0,0] )
 
-        compatibleColors(colorBtns)
-        self.assertEqual(len(prefs.keyp_colors_channel_prog),22);
+		compatibleColors(colorBtns)
+		self.assertEqual(len(prefs.keyp_colors_channel_prog),22);
 
 if __name__ == '__main__':
-    unittest.main()
+	unittest.main()

--- a/v2m.py
+++ b/v2m.py
@@ -50,33 +50,30 @@ if not os.path.exists( filepath ):
     sys.exit( 0 )
 
 import math
-import cv2
-from midiutil.MidiFile import MIDIFile
 import ntpath
-
-import pygame
-from pygame.locals import *
-
-from OpenGL.GL import *
-from OpenGL.GLU import *
 import time
-
 from os.path import expanduser
 
+import cv2
+import pygame
+from midiutil.MidiFile import MIDIFile
+from OpenGL.GL import *
+from OpenGL.GLU import *
+from pygame.locals import *
 
-
-print("open file [" + filepath + "]")
+print(f'open file [{filepath}]')
 vidcap = cv2.VideoCapture( filepath )
 
-outputmid= ntpath.basename( filepath ) + "_output.mid"
-#
-settingsfile= filepath + ".ini"
+outputmid= ntpath.basename( filepath ) + '_output.mid'
+
+settingsfile= filepath + '.ini'
+
+import datetime
 
 import video2midi.settings as settings
-from video2midi.prefs import prefs
 from video2midi.gl import *
 from video2midi.midi import *
-import datetime
+from video2midi.prefs import prefs
 
 width=640
 height=480
@@ -87,7 +84,7 @@ keygrab=0
 keygrabid=-1
 lastkeygrabid=-1
 
-#
+
 frame= 0
 printed_for_frame=0
 convertCvtColor=1
@@ -102,24 +99,22 @@ COLOR_BGR2RGB        =0
 print("OpenCV version:" + cv2.__version__ )
 
 if cv2.__version__.startswith('2.'):
- CAP_PROP_FRAME_COUNT  = cv2.cv.CV_CAP_PROP_FRAME_COUNT
- CAP_PROP_POS_FRAMES   = cv2.cv.CV_CAP_PROP_POS_FRAMES
- CAP_PROP_POS_MSEC     = cv2.cv.CV_CAP_PROP_POS_MSEC
- CAP_PROP_FRAME_WIDTH  = cv2.cv.CV_CAP_PROP_FRAME_WIDTH
- CAP_PROP_FRAME_HEIGHT = cv2.cv.CV_CAP_PROP_FRAME_HEIGHT
- CAP_PROP_FPS          = cv2.cv.CV_CAP_PROP_FPS
+  CAP_PROP_FRAME_COUNT  = cv2.cv.CV_CAP_PROP_FRAME_COUNT
+  CAP_PROP_POS_FRAMES   = cv2.cv.CV_CAP_PROP_POS_FRAMES
+  CAP_PROP_POS_MSEC     = cv2.cv.CV_CAP_PROP_POS_MSEC
+  CAP_PROP_FRAME_WIDTH  = cv2.cv.CV_CAP_PROP_FRAME_WIDTH
+  CAP_PROP_FRAME_HEIGHT = cv2.cv.CV_CAP_PROP_FRAME_HEIGHT
+  CAP_PROP_FPS          = cv2.cv.CV_CAP_PROP_FPS
 else:
- # 3, 4 , etc ...
- CAP_PROP_FRAME_COUNT  = cv2.CAP_PROP_FRAME_COUNT
- CAP_PROP_POS_FRAMES   = cv2.CAP_PROP_POS_FRAMES
- CAP_PROP_POS_MSEC     = cv2.CAP_PROP_POS_MSEC
- CAP_PROP_FRAME_WIDTH  = cv2.CAP_PROP_FRAME_WIDTH
- CAP_PROP_FRAME_HEIGHT = cv2.CAP_PROP_FRAME_HEIGHT
- CAP_PROP_FPS          = cv2.CAP_PROP_FPS
+  # 3, 4 , etc ...
+  CAP_PROP_FRAME_COUNT  = cv2.CAP_PROP_FRAME_COUNT
+  CAP_PROP_POS_FRAMES   = cv2.CAP_PROP_POS_FRAMES
+  CAP_PROP_POS_MSEC     = cv2.CAP_PROP_POS_MSEC
+  CAP_PROP_FRAME_WIDTH  = cv2.CAP_PROP_FRAME_WIDTH
+  CAP_PROP_FRAME_HEIGHT = cv2.CAP_PROP_FRAME_HEIGHT
+  CAP_PROP_FPS          = cv2.CAP_PROP_FPS
 
 COLOR_BGR2RGB         = cv2.COLOR_BGR2RGB
-
-#
 
 vidcap.set(CAP_PROP_POS_FRAMES, frame)
 vidcap.set(cv2.CAP_PROP_BUFFERSIZE, 2)
@@ -135,7 +130,7 @@ fps    = float(vidcap.get(CAP_PROP_FPS))
 width = video_width
 height = video_height
 
-def fit_to_the_screen():
+def fit_to_the_screen() -> None:
   global width, height
   infoObject = pygame.display.Info()
   if (width > infoObject.current_w) or ( height > infoObject.current_h):
@@ -154,8 +149,8 @@ endframe = length
 showoutputpath = 0
 
 
-def resize_window():
-  global screen,  width, height
+def resize_window() -> None:
+  global screen, width, height
 
   if prefs.resize:
     width = prefs.resize_width
@@ -165,11 +160,11 @@ def resize_window():
     height = video_height
     fit_to_the_screen()
   screen = pygame.display.set_mode((width,height), DOUBLEBUF|OPENGL|pygame.RESIZABLE)
-  #
+
   doinit()
 
 # set start frame
-def getFrame( framenum =-1 ):
+def getFrame(framenum:int = -1) -> None:
   global image
   global success
   global width
@@ -179,7 +174,7 @@ def getFrame( framenum =-1 ):
 
 
   if ( fps == 0 ):
-   return
+    return
 
   if ( framenum != -1 ):
     #vidcap.set(CAP_PROP_POS_FRAMES, int(framenum) )
@@ -194,19 +189,18 @@ def getFrame( framenum =-1 ):
       success = vidcap.set(CAP_PROP_POS_FRAMES, int(oldframenum) )
     curframe = vidcap.get(CAP_PROP_POS_FRAMES)
     if (curframe != framenum ):
-     print("OpenCV bug, Requesting frame " + str(framenum) + " but get position on " +str(curframe))
+      print("OpenCV bug, Requesting frame " + str(framenum) + " but get position on " +str(curframe))
 
 
   success,image = vidcap.read()
 #  if ( resize == 1 ):
 #    image = cv2.resize(image, (resize_width , resize_height))
 #    print "resize to "+str(resize_width) + "x"+ str(resize_height)
-  pass
 
 getFrame()
 
 
-#
+
 print("video " + str(width) + "x" + str(height) +" fps: " + str(fps))
 
 # add some notes
@@ -237,9 +231,9 @@ colorBtns = []
 #quantized notes to the grid.
 use_snap_notes_to_grid = False
 notes_grid_size=32
-#
+
 midi_file_format = 0
-#
+
 line_height = 20
 running = 1
 
@@ -250,7 +244,7 @@ if os.path.exists( 'v2m.ini' ):
   inifile="v2m.ini"
   print("local config file exists.")
 
-def update_size():
+def update_size() -> None:
   global width, height
   if ( prefs.resize == 1 ):
     width = prefs.resize_width
@@ -258,7 +252,7 @@ def update_size():
   else:
     fit_to_the_screen()
 
-def loadsettings(cfgfile):
+def loadsettings(cfgfile: str) -> None:
   global colorBtns, colorWindow_colorBtns_channel_labels
 
   settings.loadsettings(cfgfile)
@@ -285,7 +279,6 @@ def loadsettings(cfgfile):
     notes_overlap_btn.switch_status = prefs.notes_overlap
     ignore_notes_with_minimal_duration_btn.switch_status = prefs.ignore_minimal_duration
 
-  pass
 
 update_size
 
@@ -296,10 +289,10 @@ for i in range(144):
   notes_channel.append(0)
   notes_tmp.append(0)
   notes_pressed_color.append([0,0,0])
-  #
+
   prefs.keyp_colors_alternate.append([0,0,0])
   prefs.keyp_colors_alternate_sensitivity.append(0)
-#
+
 
 
 
@@ -332,7 +325,6 @@ def updatekeys( append=0 ):
  for i in range(len(prefs.keys_pos)):
    prefs.keys_pos[i] = v_rotate( prefs.keys_pos[i] , prefs.keys_angle )
    prefs.keys_pos[i][0] = - prefs.keys_pos[i][0]
- pass
 
 
 
@@ -403,9 +395,6 @@ def loadImage(idframe=130):
     except Exception as E:
       print("Can't load image from video to OpenGL: %s" % E);
 
-
-  pass
-
 def update_channels(sender):
    print( 'update_channels...' +str(sender.index))
    i=abs(sender.index) -1
@@ -448,18 +437,18 @@ def readkeycolor(i):
 
 
 def readcolors(sender):
-   for i in range( len(prefs.keys_pos) ):
+  for i in range( len(prefs.keys_pos) ):
     readkeycolor(i)
 
 def update_alternate_sensitivity(sender,value):
-   global lastkeygrabid
-   if ( lastkeygrabid != -1 ):
-     prefs.keyp_colors_alternate_sensitivity[ lastkeygrabid ] = value
+  global lastkeygrabid
+  if ( lastkeygrabid != -1 ):
+    prefs.keyp_colors_alternate_sensitivity[ lastkeygrabid ] = value
 
 def update_sparks_delta(sender,value):
-   if (sender.id == -1):
-     return
-   if (sender.id < len(prefs.keyp_colors))  :
+  if (sender.id == -1):
+    return
+  if (sender.id < len(prefs.keyp_colors))  :
     prefs.keyp_colors_sparks_sensitivity[sender.id] = sender.value
     #print("keyp_colors_sparks_sensitivity["+str(sender.id)+"] = "+ str(sender.value) )
 
@@ -471,32 +460,31 @@ def update_sync_notes_start_pos_time_delta(sender,value):
   prefs.sync_notes_start_pos_time_delta = value *0.001
 
 def change_use_alternate_keys(sender):
-   global extra_label1
-   prefs.use_alternate_keys = not prefs.use_alternate_keys
-   update_alternate_label()
+  global extra_label1
+  prefs.use_alternate_keys = not prefs.use_alternate_keys
+  update_alternate_label()
 
 def update_alternate_label():
   extra_label1.text = "Use alternate:"+str(prefs.use_alternate_keys)
 
 def change_use_sparks(sender):
-   prefs.use_sparks = sender.switch_status
+  prefs.use_sparks = sender.switch_status
 #   sender.text = "use sparks:"+str(use_sparks)
 def change_rollcheck(sender):
-   prefs.rollcheck = sender.switch_status
+  prefs.rollcheck = sender.switch_status
 
 def change_rollcheck_priority(sender):
-   prefs.rollcheck_priority = sender.switch_status
+  prefs.rollcheck_priority = sender.switch_status
 
 def updatecolor(sender):
-   if (lastkeygrabid != -1):
+  if (lastkeygrabid != -1):
     readkeycolor(lastkeygrabid)
 
 def update_sparks_y_pos (sender):
-   if (sender.text == "y+"):
-     prefs.keyp_spark_y_pos =  prefs.keyp_spark_y_pos -1
-   else:
-     prefs.keyp_spark_y_pos =  prefs.keyp_spark_y_pos +1
-   pass
+  if (sender.text == 'y+'):
+    prefs.keyp_spark_y_pos = prefs.keyp_spark_y_pos -1
+  else:
+    prefs.keyp_spark_y_pos = prefs.keyp_spark_y_pos +1
 
 def update_line_height(sender,value):
   global line_height
@@ -504,8 +492,8 @@ def update_line_height(sender,value):
 
 
 def snap_notes_to_the_grid(sender):
-    global use_snap_notes_to_grid
-    use_snap_notes_to_grid = sender.switch_status
+  global use_snap_notes_to_grid
+  use_snap_notes_to_grid = sender.switch_status
 
 def raise_octave(*args):
   global basenote
@@ -539,7 +527,7 @@ def update_percolor_delta(sender,value):
     #print("changed percolor delta for color with id ["+str(sender.id)+"] = "+ str(sender.value) )
 
 def showOrhideallwindows(sender):
-  if sender == None:
+  if sender is None:
     ShowHideButton.switch_status = not ShowHideButton.switch_status
   print('switch hidden for all windows')
   for i in glwindows:
@@ -553,7 +541,6 @@ def start_recreate_midi(sender):
     running = 0
   else:
     reconstruct()
-  pass
 
 def set_start_frame_to_current_frame(sender):
   if sender.index == 0:
@@ -561,7 +548,6 @@ def set_start_frame_to_current_frame(sender):
   else:
     prefs.startframe = 0
   print("set start frame = "+ str(prefs.startframe))
-  pass
 
 def sef_end_frame_to_current_frame(sender):
   global endframe
@@ -570,36 +556,30 @@ def sef_end_frame_to_current_frame(sender):
   else:
     endframe = length
   print("set end frame = "+ str(endframe), sender.index)
-  pass
 
 def switch_notes_overlap(sender):
-  if sender == None:
+  if sender is None:
     prefs.notes_overlap = not prefs.notes_overlap
     notes_overlap_btn.switch_status = prefs.notes_overlap
   else:
     prefs.notes_overlap = notes_overlap_btn.switch_status
-  pass
 
 def switch_sync_notes_start_pos(sender):
   prefs.sync_notes_start_pos = sender.switch_status
-  pass
 
 def change_save_to_disk_per_channel(sender):
   prefs.save_to_disk_per_channel = sender.switch_status
-  pass
 
 def switch_ignore_notes_with_minimal_duration(sender):
-  if sender == None:
+  if sender is None:
     prefs.ignore_minimal_duration = not prefs.ignore_minimal_duration
     ignore_notes_with_minimal_duration_btn.switch_status = prefs.ignore_minimal_duration
   else:
     prefs.ignore_minimal_duration = ignore_notes_with_minimal_duration_btn.switch_status
-  pass
 
 def switch_resize_windows(sender):
   prefs.resize = not prefs.resize
   resize_window()
-  pass
 
 def scroll_by_steps( steps ):
   global frame
@@ -610,37 +590,30 @@ def scroll_by_steps( steps ):
     frame=1
   glBindTexture(GL_TEXTURE_2D, Gl.bgImgGL)
   loadImage(frame)
-  pass
 
 def scroll_forward_by_frame(sender):
   scroll_by_steps(1)
-  pass
 
 def scroll_fast_forward(sender):
   scroll_by_steps(100)
-  pass
 
 def scroll_prev_by_frame(sender):
   scroll_by_steps(-1)
-  pass
 
 def scroll_fast_prev(sender):
   scroll_by_steps(-100)
-  pass
 
 def scroll_to_start(sender):
   global frame
   frame=0
   glBindTexture(GL_TEXTURE_2D, Gl.bgImgGL)
   loadImage(frame)
-  pass
 
 def scroll_to_end(sender):
   global frame
   frame=length-100
   glBindTexture(GL_TEXTURE_2D, Gl.bgImgGL)
   loadImage(frame)
-  pass
 
 def btndown_save_settings(sender):
   settings.savesettings(settingsfile)
@@ -653,7 +626,7 @@ def btndown_load_settings(sender):
     resize_window()
 
 def change_autoclose(sender):
-   prefs.autoclose = sender.switch_status
+  prefs.autoclose = sender.switch_status
 
 def rotate_cw(sender):
   prefs.keys_angle -= 5
@@ -663,9 +636,6 @@ def rotate_ccw(sender):
   updatekeys()
 
 
-
-
-#
 wh = ( (len(prefs.keyp_colors) // 2)+2 ) * 24 - 24
 colorWindow = GLWindow(24, 50, 274, wh, "color map")
 settingsWindow = GLWindow(24+275, 80, 550, 340, "Settings")
@@ -812,7 +782,7 @@ for i in range( len( prefs.keyp_colors ) ):
 
  colorWindow_colorBtns_channel_labels.append( colorWindow_label1 )
  colorWindow.appendChild(colorWindow_label1)
- #
+
  colorWindow_colorBtns_channel_btns.append( GLButton(offsetx+cx+70,offsety+cy ,20,20,(i+1), [128,128,128], "+" ,update_channels) )
  colorWindow_colorBtns_channel_btns.append( GLButton(offsetx+cx+70+20,offsety+cy ,20,20,-(i+1), [128,128,128], "-" ,update_channels) )
  colorWindow_colorBtns_channel_btns.append( GLButton(offsetx+cx+70+40,offsety+cy ,20,20,i, [128,128,128], "x" ,disable_color, hint="ctrl+0 - shortcut, disable selected color") )
@@ -871,7 +841,7 @@ sparksWindow.appendChild( use_percolor_delta )
 #loadsettings( settingsfile )
 #frame=801
 
-def getkeyp_pixel_pos( x, y ):
+def getkeyp_pixel_pos( x:int, y:int ) -> list[int]:
   pixx=int(prefs.xoffset_whitekeys + x)
   pixy=int(prefs.yoffset_whitekeys + y)
 
@@ -886,12 +856,11 @@ def getkeyp_pixel_pos( x, y ):
     if ( pixy > video_height-1 ): pixy= video_height-1
   return [pixx,pixy]
 
-def iswhitekey( key_num ):
+def iswhitekey( key_num: int ) -> int:
   j = key_num % 12
   if (j == 1) or ( j ==3 ) or ( j == 6 ) or ( j == 8) or ( j == 10 ):
     return 1
-  else:
-    return 0
+  return 0
 
 def drawframe( lastimage = None):
  global pyfont
@@ -1227,7 +1196,7 @@ def processmidi():
            if ( not has_spark_delta ):
              keypressed=0
 
-    #
+
     if ( keypressed != 0 ):
        note_channel=prefs.keyp_colors_channel[ deltaid ]
 
@@ -1439,7 +1408,7 @@ def main():
   doinit()
 
   clock = pygame.time.Clock()
-  #
+
   # set start frame
   vidcap.set(CAP_PROP_POS_FRAMES, frame)
 
@@ -1598,8 +1567,7 @@ def main():
         for i in range( len( prefs.keys_pos) ):
          if (abs( mousex - (prefs.keys_pos[i][0] + prefs.xoffset_whitekeys) )< size) and (abs( mousey - (prefs.keys_pos[i][1] + prefs.yoffset_whitekeys) )< size):
            separate_note_id=i
-           pass
-     #
+
      elif event.type == pygame.MOUSEBUTTONUP:
       for i in range( len(glwindows)-1, -1 , -1):
         #print("process mouse up on windiws id: ", i)
@@ -1608,13 +1576,13 @@ def main():
           resort=True
           break
 
-      #
+
       if ( event.button == 1 ):
         keygrab = 0
         keygrabid = -1
       if ( event.button == 3 ):
         keygrab = 0
-     #
+
      elif event.type == pygame.MOUSEBUTTONDOWN:
       resort=False
       for i in range( len(glwindows)-1, -1 , -1):
@@ -1635,7 +1603,7 @@ def main():
         prefs.whitekey_width-=0.05
 #        print "whitekey_width="+str(whitekey_width)
         updatekeys( )
-#
+
       if ( event.button == 1 ):
         if mods & pygame.KMOD_CTRL and Gl.keyp_colormap_id != -1:
          pixx = int(mousex)
@@ -1657,8 +1625,6 @@ def main():
          if not colorWindow.active and not mouseOnWindows:
             Gl.keyp_colormap_id = -1
          #keyp_colormap_id = -1
-         pass
-        #
         size=5
         if (mods & pygame.KMOD_CTRL):
           lastkeygrabid=-1
@@ -1672,7 +1638,6 @@ def main():
           extra_slider1.setvalue( prefs.keyp_colors_alternate_sensitivity[i] )
           print("ok click found on : "+str(keygrabid))
           break
-        pass
 #      if ( event.button == 2 ):
 #        lastkeygrabid=-1
       if ( event.button == 3 ):
@@ -1707,4 +1672,4 @@ def main():
 main()
 if prefs.autoclose == 1:
   reconstruct()
-print ("done...")
+print ('done...')

--- a/v2m.py
+++ b/v2m.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # by svsd_val
 # jabber : svsd_val@jabber.ru
@@ -39,7 +38,7 @@ if not os.path.exists( filepath ):
     yt = YouTube( filepath )
     videos = [ { 'itag' : i.itag, 'res' : int(re.sub('[^0-9]','', i.resolution)), 'progressive' : int(i.is_progressive) }  for i in yt.streams.filter(file_extension='mp4') if i.mime_type.find("video") != -1 ]
     print(videos)
-    videos = sorted( videos , key = lambda d : ( -d['progressive'], - d['res']) ) 
+    videos = sorted( videos , key = lambda d : ( -d['progressive'], - d['res']) )
     print('sorted by progressive (has video & audio in same file) and video resolution')
     for i in videos:
       print('processing: %s' % i)
@@ -391,7 +390,7 @@ def loadImage(idframe=130):
   except Exception as E:
      error_on_load=True
      print("Can't load image from video to OpenGL: %s" % E);
-  
+
   if error_on_load:
     rvideo_width, rvideo_height = 512, 512
     print("Trying resize video image to %sx%s" % (rvideo_width, rvideo_height));
@@ -403,7 +402,7 @@ def loadImage(idframe=130):
          glTexImage2D(GL_TEXTURE_2D, 0, 3, rvideo_width, rvideo_height, 0, GL_BGR, GL_UNSIGNED_BYTE, rimage )
     except Exception as E:
       print("Can't load image from video to OpenGL: %s" % E);
-    
+
 
   pass
 

--- a/video2midi/gl.py
+++ b/video2midi/gl.py
@@ -1,6 +1,9 @@
-import pygame
+from __future__ import annotations
+
 import sys
 import time
+
+import pygame
 from OpenGL.GL import *
 from OpenGL.GLU import *
 
@@ -11,897 +14,854 @@ fontSize=24
 fontChars = u''' !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz><'''
 
 class Gl:
-  fontTexture = -1
-  bgImgGL=-1
-  listQuad1=-1
-  listRect1=-1
-  glDrawPixelsText = 0
-  keyp_colormap_id=-1
+	fontTexture = -1
+	bgImgGL=-1
+	listQuad1=-1
+	listRect1=-1
+	glDrawPixelsText = 0
+	keyp_colormap_id=-1
 
-def doinitGl():
-  Gl.listQuad1=-1
-  for fnt in fonts:
-    fnt.gllistid = -1
-  glPixelStorei(GL_UNPACK_ALIGNMENT,1)
-  Gl.bgImgGL = glGenTextures(1)
-  Gl.fontTexture = glGenTextures(1)
-  glBindTexture(GL_TEXTURE_2D, Gl.bgImgGL)
+def doinitGl() -> None:
+	Gl.listQuad1=-1
+	for fnt in fonts:
+		fnt.gllistid = -1
+	glPixelStorei(GL_UNPACK_ALIGNMENT,1)
+	Gl.bgImgGL = glGenTextures(1)
+	Gl.fontTexture = glGenTextures(1)
+	glBindTexture(GL_TEXTURE_2D, Gl.bgImgGL)
 
+def DrawQuad(vx,vy,vx2,vy2) -> None:
+	if Gl.listQuad1 == -1 :
+		Gl.listQuad1 = glGenLists(1)
+		glNewList(Gl.listQuad1, GL_COMPILE)
 
-def DrawQuad(vx,vy,vx2,vy2,):
-  if Gl.listQuad1 == -1 :
-    Gl.listQuad1 = glGenLists(1)
-    glNewList(Gl.listQuad1, GL_COMPILE)
-    #
-    glBegin(GL_QUADS)
-    glTexCoord2f(0, 0)
-    glVertex2f(0, 0)
-    glTexCoord2f(1, 0)
-    glVertex2f(1, 0)
-    glTexCoord2f(1, 1)
-    glVertex2f(1, 1)
-    glTexCoord2f(0, 1)
-    glVertex2f(0, 1)
-    glEnd()
-    #
-    glEndList()
-    glCallList(Gl.listQuad1)
-  else:
-    glPushMatrix()
-    glTranslatef(vx,vy,0)
-    glScalef(vx2-vx,vy2-vy,1)
-    glCallList(Gl.listQuad1)
-    glPopMatrix()
-  #
-  pass
+		glBegin(GL_QUADS)
+		glTexCoord2f(0, 0)
+		glVertex2f(0, 0)
+		glTexCoord2f(1, 0)
+		glVertex2f(1, 0)
+		glTexCoord2f(1, 1)
+		glVertex2f(1, 1)
+		glTexCoord2f(0, 1)
+		glVertex2f(0, 1)
+		glEnd()
 
-def DrawQuad_old(x,y,x2,y2, texx=1, texy=-1):
-  glBegin(GL_QUADS)
-  glTexCoord2f(0, texy)
-  glVertex2f(x, y)
-  glTexCoord2f(texx, texy)
-  glVertex2f(x2, y)
-  glTexCoord2f(texx, 0)
-  glVertex2f(x2, y2)
-  glTexCoord2f(0, 0)
-  glVertex2f(x, y2)
-  glEnd()
-  pass
+		glEndList()
+		glCallList(Gl.listQuad1)
+	else:
+		glPushMatrix()
+		glTranslatef(vx,vy,0)
+		glScalef(vx2-vx,vy2-vy,1)
+		glCallList(Gl.listQuad1)
+		glPopMatrix()
 
-def DrawRect(vx,vy,vx2,vy2,w=1):
-  glLineWidth(w)
-  if Gl.listRect1 == -1 :
-    Gl.listRect1 = glGenLists(1)
-    glNewList(Gl.listRect1, GL_COMPILE)
-    x=0
-    y=0
-    x2=1
-    y2=1
+def DrawQuad_old(x,y,x2,y2, texx=1, texy=-1) -> None:
+	glBegin(GL_QUADS)
+	glTexCoord2f(0, texy)
+	glVertex2f(x, y)
+	glTexCoord2f(texx, texy)
+	glVertex2f(x2, y)
+	glTexCoord2f(texx, 0)
+	glVertex2f(x2, y2)
+	glTexCoord2f(0, 0)
+	glVertex2f(x, y2)
+	glEnd()
 
-    glBegin(GL_LINE_LOOP)
-    glVertex2f(x, y)
-    glVertex2f(x2, y)
-    glVertex2f(x2, y2)
-    glVertex2f(x, y2)
-    glEnd()
-    glEndList()
-    glCallList(Gl.listRect1)
-  else:
-    glPushMatrix()
-    glTranslatef(vx,vy,0)
-    glScalef(vx2-vx,vy2-vy,1)
-    glCallList(Gl.listRect1)
-    glPopMatrix()
-  #
-  pass
+def DrawRect(vx,vy,vx2,vy2,w=1) -> None:
+	glLineWidth(w)
+	if Gl.listRect1 == -1 :
+		Gl.listRect1 = glGenLists(1)
+		glNewList(Gl.listRect1, GL_COMPILE)
+		x=0
+		y=0
+		x2=1
+		y2=1
 
+		glBegin(GL_LINE_LOOP)
+		glVertex2f(x, y)
+		glVertex2f(x2, y)
+		glVertex2f(x2, y2)
+		glVertex2f(x, y2)
+		glEnd()
+		glEndList()
+		glCallList(Gl.listRect1)
+	else:
+		glPushMatrix()
+		glTranslatef(vx,vy,0)
+		glScalef(vx2-vx,vy2-vy,1)
+		glCallList(Gl.listRect1)
+		glPopMatrix()
 
-def DrawRect_old(x,y,x2,y2,w=1):
-  glLineWidth(w)
-  glBegin(GL_LINE_LOOP)
-  glVertex2f(x, y)
-  glVertex2f(x2, y)
-  glVertex2f(x2, y2)
-  glVertex2f(x, y2)
-  glEnd()
-  pass
+def DrawRect_old(x,y,x2,y2,w=1) -> None:
+	glLineWidth(w)
+	glBegin(GL_LINE_LOOP)
+	glVertex2f(x, y)
+	glVertex2f(x2, y)
+	glVertex2f(x2, y2)
+	glVertex2f(x, y2)
+	glEnd()
 
-def DrawQuadT(x,y,x2,y2):
-  glBegin(GL_QUADS)
-  glTexCoord2i(0, 1)
-  glVertex2f(x, y)
-  glTexCoord2i(1, 1)
-  glVertex2f(x2, y)
-  glTexCoord2i(1, 0)
-  glVertex2f(x2, y2)
-  glTexCoord2i(0, 0)
-  glVertex2f(x, y2)
-  glEnd()
-  pass
+def DrawQuadT(x,y,x2,y2) -> None:
+	glBegin(GL_QUADS)
+	glTexCoord2i(0, 1)
+	glVertex2f(x, y)
+	glTexCoord2i(1, 1)
+	glVertex2f(x2, y)
+	glTexCoord2i(1, 0)
+	glVertex2f(x2, y2)
+	glTexCoord2i(0, 0)
+	glVertex2f(x, y2)
+	glEnd()
 
-def DrawTriangle(x,y, s,r=0):
-  glBegin(GL_TRIANGLES)
-  if ( r == 0 ):
-    glVertex2f(x , y-s)
-    glVertex2f(x + s, y-s)
-    glVertex2f(x + s*0.5, y)
-  else:
-    glVertex2f(x , y)
-    glVertex2f(x + s,y)
-    glVertex2f(x + s*0.5, y-s)
-  glEnd()
-  pass
+def DrawTriangle(x,y, s,r=0) -> None:
+	glBegin(GL_TRIANGLES)
+	if ( r == 0 ):
+		glVertex2f(x , y-s)
+		glVertex2f(x + s, y-s)
+		glVertex2f(x + s*0.5, y)
+	else:
+		glVertex2f(x , y)
+		glVertex2f(x + s,y)
+		glVertex2f(x + s*0.5, y-s)
+	glEnd()
 
 class GLFont:
-  def __init__(self,tx,ty,tx2,ty2, fw,fh, char):
-    self.ty2 = ty2
-    self.tx2 = tx2
-    self.tx = tx
-    self.ty = ty
-    self.fw = fw
-    self.fh = fh
-    self.char = char
-    self.gllistid = -1
-    pass
+	def __init__(self,tx,ty,tx2,ty2, fw,fh, char) -> None:
+		self.ty2 = ty2
+		self.tx2 = tx2
+		self.tx = tx
+		self.ty = ty
+		self.fw = fw
+		self.fh = fh
+		self.char = char
+		self.gllistid = -1
 
 fonts = []
 
-def getTextSize(text):
-  sizes = [0,0]
-  for i in text:
-    fid = int(ord( i )) - 32
-    if fid < 0 or fid >= len(fonts): continue
-    j = fonts[ fid ]
-    if j.fh > sizes[1]:
-      sizes[1] = j.fh
-    sizes[0] = sizes[0] + j.fw
-  #print( text , sizes )
-  return sizes
+def getTextSize(text) -> list[int]:
+	sizes = [0,0]
+	for i in text:
+		fid = int(ord( i )) - 32
+		if fid < 0 or fid >= len(fonts): continue
+		j = fonts[ fid ]
+		if j.fh > sizes[1]:
+			sizes[1] = j.fh
+		sizes[0] = sizes[0] + j.fw
+	#print( text , sizes )
+	return sizes
 
 
-def RenderText(x,y, text):
-  global fontChars
-  global fonts
-  glPushAttrib(GL_ENABLE_BIT)
+def RenderText(x,y, text) -> None:
+	global fontChars
+	global fonts
+	glPushAttrib(GL_ENABLE_BIT)
 
-  glDisable(GL_DEPTH_TEST)
-  glDisable(GL_CULL_FACE)
+	glDisable(GL_DEPTH_TEST)
+	glDisable(GL_CULL_FACE)
 
-  glEnable(GL_TEXTURE_2D)
-  glEnable(GL_BLEND)
+	glEnable(GL_TEXTURE_2D)
+	glEnable(GL_BLEND)
 
-  glEnable(GL_ALPHA_TEST)
-  glAlphaFunc(GL_GEQUAL, 0.1)
+	glEnable(GL_ALPHA_TEST)
+	glAlphaFunc(GL_GEQUAL, 0.1)
 
-  #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-  glBlendFunc(GL_ONE, GL_SRC_ALPHA)
-  #
-  glBindTexture(GL_TEXTURE_2D,Gl.fontTexture)
+	#glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+	glBlendFunc(GL_ONE, GL_SRC_ALPHA)
 
-  glPushMatrix()
+	glBindTexture(GL_TEXTURE_2D,Gl.fontTexture)
 
-
-  glTranslatef(x,y-21,0)
-  glColor4f(1.0, 1.0, 1.0, 1.0)
-  for i in text:
-    fid=0
-    #Is this really so terribly slow to find the need charset O_o ?!
-    #
-    #for fid in range(len(fonts)):
-    #  if i == fonts[fid].char
-    #    break
-
-    fid = int(ord( i )) - 32
-    if fid < 0 or fid >= len(fonts): continue
-    j = fonts[ fid ]
-    if i == ' ' :
-      glTranslatef(j.fw,0,0)
-      continue
-
-    if j.gllistid == -1 :
-
-      #PyOpenGL terribly slow =( so... trying to optimize ...
-      gllist = glGenLists(1)
-      glNewList(gllist, GL_COMPILE)
-      glBegin(GL_QUADS)
-      glTexCoord2f(j.tx, j.ty)
-      glVertex2f(0, 0)
-      glTexCoord2f(j.tx2, j.ty)
-      glVertex2f(j.fw, 0)
-      glTexCoord2f(j.tx2, j.ty2)
-      glVertex2f(j.fw, j.fh)
-      glTexCoord2f(j.tx, j.ty2)
-      glVertex2f(0, j.fh)
-      glEnd()
-
-      glEndList()
-      fonts[fid].gllistid = gllist
-      glCallList(gllist)
-#      print "new list created : ", gllist
-    else:
-#      print "calling list : ", j.vbo
-      glCallList(j.gllistid)
-
-    glTranslatef(j.fw,0,0)
-  glPopMatrix()
-  glPopAttrib()
-  pass
+	glPushMatrix()
 
 
-def GenFontTexture():
-  global fontChars
-  global fonts
-  global fontSize
+	glTranslatef(x,y-21,0)
+	glColor4f(1.0, 1.0, 1.0, 1.0)
+	for i in text:
+		fid=0
+		#Is this really so terribly slow to find the need charset O_o ?!
+		#
+		#for fid in range(len(fonts)):
+		#	if i == fonts[fid].char
+		#		break
 
-  #surface
-  texture_buffer_surf = pygame.Surface((512, 512))
-  texture_buffer_surf.fill(pygame.Color('black'))
-  if sys.platform.startswith('win'):
-    font = pygame.font.SysFont( 'Arial' , fontSize-10 )
-  else:
-    font = pygame.font.Font( None , fontSize )
+		fid = int(ord( i )) - 32
+		if fid < 0 or fid >= len(fonts): continue
+		j = fonts[ fid ]
+		if i == ' ' :
+			glTranslatef(j.fw,0,0)
+			continue
 
-  x = 2
-  y = 0
-  for i in range(len(fontChars)):
-    y = i // 32
-    #
-    textSurface = font.render( fontChars[i] , True, (255,255,255,255))
-    #
-    ix, iy = textSurface.get_width(), textSurface.get_height()
-    texture_buffer_surf.blit(textSurface, (x, y*fontSize, 0, 0))
-    fnt =  GLFont(x / 512.0 ,1 - (y*fontSize -2) / 512.0, (x+ix) / 512.0,1 - (y*fontSize+fontSize-2) / 512.0, ix,fontSize, fontChars[i])
+		if j.gllistid == -1 :
 
-    fonts.append( fnt )
+			#PyOpenGL terribly slow =( so... trying to optimize ...
+			gllist = glGenLists(1)
+			glNewList(gllist, GL_COMPILE)
+			glBegin(GL_QUADS)
+			glTexCoord2f(j.tx, j.ty)
+			glVertex2f(0, 0)
+			glTexCoord2f(j.tx2, j.ty)
+			glVertex2f(j.fw, 0)
+			glTexCoord2f(j.tx2, j.ty2)
+			glVertex2f(j.fw, j.fh)
+			glTexCoord2f(j.tx, j.ty2)
+			glVertex2f(0, j.fh)
+			glEnd()
 
-    x += ix + 2
-    if (i % 32 == 31 ) and (i != 0): x=2
+			glEndList()
+			fonts[fid].gllistid = gllist
+			glCallList(gllist)
+#			print "new list created : ", gllist
+		else:
+#			print "calling list : ", j.vbo
+			glCallList(j.gllistid)
 
-  tex_data = pygame.image.tostring(texture_buffer_surf, "RGBA", 1)
+		glTranslatef(j.fw,0,0)
+	glPopMatrix()
+	glPopAttrib()
 
-  # fix alpha ...
-  l = list( tex_data )
-  #
-  for y in range(512):
-    for x in range(512):
-      l[ (y*512+x) * 4 +3 ] = l[ (y*512+x) * 4 +0 ]
+def GenFontTexture() -> None:
+	global fontChars
+	global fonts
+	global fontSize
 
-  if sys.version_info >= (3, 0):
-    tex_data4 = l
-  else:
-    tex_data4 = ''.join(l)
-  #
-  glBindTexture(GL_TEXTURE_2D, Gl.fontTexture)
+	#surface
+	texture_buffer_surf = pygame.Surface((512, 512))
+	texture_buffer_surf.fill(pygame.Color('black'))
+	if sys.platform.startswith('win'):
+		font = pygame.font.SysFont( 'Arial' , fontSize-10 )
+	else:
+		font = pygame.font.Font( None , fontSize )
 
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT)
-  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT)
-  glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_DECAL)
+	x = 2
+	y = 0
+	for i in range(len(fontChars)):
+		y = i // 32
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 512, 512, 0, GL_RGBA, GL_UNSIGNED_BYTE, tex_data4 )
-  pass
+		textSurface = font.render( fontChars[i] , True, (255,255,255,255))
+
+		ix, iy = textSurface.get_width(), textSurface.get_height()
+		texture_buffer_surf.blit(textSurface, (x, y*fontSize, 0, 0))
+		fnt =	GLFont(x / 512.0 ,1 - (y*fontSize -2) / 512.0, (x+ix) / 512.0,1 - (y*fontSize+fontSize-2) / 512.0, ix,fontSize, fontChars[i])
+
+		fonts.append( fnt )
+
+		x += ix + 2
+		if (i % 32 == 31 ) and (i != 0): x=2
+
+	tex_data = pygame.image.tostring(texture_buffer_surf, "RGBA", 1)
+
+	# fix alpha ...
+	l = list( tex_data )
+
+	for y in range(512):
+		for x in range(512):
+			l[ (y*512+x) * 4 +3 ] = l[ (y*512+x) * 4 +0 ]
+
+	tex_data4 = l
+
+	glBindTexture(GL_TEXTURE_2D, Gl.fontTexture)
+
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT)
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT)
+	glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_DECAL)
+
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 512, 512, 0, GL_RGBA, GL_UNSIGNED_BYTE, tex_data4 )
 
 
+def drawText(position, color, textString, size=24) -> None:
+	if not Gl.glDrawPixelsText :
+		RenderText(position[0],position[1], textString)
+	else:
+		glEnable(GL_BLEND)
+		glBlendFunc(GL_ONE, GL_SRC_ALPHA)
+		font = pygame.font.Font (None, size)
+		textSurface = font.render(textString, True, (color[0],color[1],color[2],255), (0,0,0,0))
+		textData = pygame.image.tostring(textSurface, "RGBA", True)
+		glRasterPos3d(*position)
+		glDrawPixels(textSurface.get_width(), textSurface.get_height(), GL_RGBA, GL_UNSIGNED_BYTE, textData)
 
-def drawText(position, color, textString, size=24):
-  if not Gl.glDrawPixelsText :
-    RenderText(position[0],position[1], textString)
-  else:
-    glEnable(GL_BLEND)
-    glBlendFunc(GL_ONE, GL_SRC_ALPHA)
-    font = pygame.font.Font (None, size)
-    textSurface = font.render(textString, True, (color[0],color[1],color[2],255), (0,0,0,0))
-    textData = pygame.image.tostring(textSurface, "RGBA", True)
-    glRasterPos3d(*position)
-    glDrawPixels(textSurface.get_width(), textSurface.get_height(), GL_RGBA, GL_UNSIGNED_BYTE, textData)
-  pass
+def drawHint(x:float,y:float, hint:str, middle:bool=False) -> None:
+	sz = getTextSize( hint )
+	xa = -sz[0] *0.25
+	if middle:
+		xa = sz[0] *0.5
 
+	glDisable(GL_TEXTURE_2D)
+	glEnable(GL_BLEND)
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+	glPushMatrix()
+	glTranslatef( 0 -xa ,0, 1)
+	glColor4f(0.1, 0.1, 0.1, 0.8)
+	DrawQuad( x , y -20 , x + sz[0] +7,y - 20 + sz[1])
+	glColor4f(0.1, 0.1, 0.1, 1)
+	DrawRect( x , y -20 , x + sz[0] +7,y - 20 + sz[1])
+	#self.mousepos
 
-def drawHint(x:float,y:float, hint:str, middle:bool=False):
-  sz = getTextSize( hint )
-  xa = -sz[0] *0.25
-  if middle:
-    xa = sz[0] *0.5
-
-  glDisable(GL_TEXTURE_2D)
-  glEnable(GL_BLEND)
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-  glPushMatrix()
-  glTranslatef( 0 -xa ,0, 1)
-  glColor4f(0.1, 0.1, 0.1, 0.8)
-  DrawQuad( x , y -20 , x + sz[0] +7,y - 20 + sz[1])
-  glColor4f(0.1, 0.1, 0.1, 1)
-  DrawRect( x , y -20 , x + sz[0] +7,y - 20 + sz[1])
-  #self.mousepos
-
-  glTranslatef( x +5 , y -18 ,0)
-  glColor4f(1.0, 1.0, 1, 1.0)
-  drawText( (0,Label_v_spacer,1),(255,255,255), hint)
-  glPopMatrix()
+	glTranslatef( x +5 , y -18 ,0)
+	glColor4f(1.0, 1.0, 1, 1.0)
+	drawText( (0,Label_v_spacer,1),(255,255,255), hint)
+	glPopMatrix()
 
 
 class GLSlider:
-  def __init__(self,x,y,w,h, vmin,vmax, value, update_func = None, label = "", color = [128, 128, 255] ):
-    self.w = float(w)
-    self.h = float(h)
-    self.x = float(x)
-    self.y = float(y)
-    self.vmin = vmin
-    self.vmax = vmax
-    self.value = value
-    self.update_func = update_func
+	def __init__(self,x,y,w,h, vmin,vmax, value, update_func = None, label = "", color = [128, 128, 255] ) -> None:
+		self.w = float(w)
+		self.h = float(h)
+		self.x = float(x)
+		self.y = float(y)
+		self.vmin = vmin
+		self.vmax = vmax
+		self.value = value
+		self.update_func = update_func
 
-#    if ( (vmax+ abs(vmin)) - vmin) != 0:
-    if ((vmax - vmin) != 0):
-      self.percent = ( (value + abs(vmin)) / float(vmax - vmin)) * 100
+#		if ( (vmax+ abs(vmin)) - vmin) != 0:
+		if ((vmax - vmin) != 0):
+			self.percent = ( (value + abs(vmin)) / float(vmax - vmin)) * 100
 
-    self.mousegrab = 0
-    self.mousepos = [0,0]
-    self.mouseclickpos = [0,0]
-    self.showvalue= False
-    self.label = label
-    self.showlabel = label != ""
-    self.showvaluesinlabel = 1
-    self.round = 2
-    self.color = color
-    self.id    = -1
-    pass
+		self.mousegrab = 0
+		self.mousepos = [0,0]
+		self.mouseclickpos = [0,0]
+		self.showvalue= False
+		self.label = label
+		self.showlabel = label != ""
+		self.showvaluesinlabel = 1
+		self.round = 2
+		self.color = color
+		self.id		= -1
 
-  def draw(self):
-    self.update()
-    glDisable(GL_TEXTURE_2D)
-    glEnable(GL_BLEND)
-    glPushMatrix()
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-    glColor4f(0.2, 0.2, 0.2, 0.9)
+	def draw(self) -> None:
+		self.update()
+		glDisable(GL_TEXTURE_2D)
+		glEnable(GL_BLEND)
+		glPushMatrix()
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		glColor4f(0.2, 0.2, 0.2, 0.9)
 
-    glTranslatef( self.x , self.y ,0)
-    glColor4f(0.8, 0.8, 0.8, 1)
-    DrawQuad(0,0,self.w+2,self.h+2)
-    glColor4ub( self.color[0], self.color[1], self.color[2], 255)
-    DrawQuad(2,2,self.percent * self.w * 0.01, self.h )
+		glTranslatef( self.x , self.y ,0)
+		glColor4f(0.8, 0.8, 0.8, 1)
+		DrawQuad(0,0,self.w+2,self.h+2)
+		glColor4ub( self.color[0], self.color[1], self.color[2], 255)
+		DrawQuad(2,2,self.percent * self.w * 0.01, self.h )
 
-    if (self.showvalue):
-      glPushMatrix()
-      glTranslatef(self.w *0.5 , self.h *0.5 + Label_v_spacer *0.5 ,0)
-      drawText( (0,0,1), (128,0,255), str(round(self.value,2)))
-      glPopMatrix()
-    if (self.showlabel):
-      labeltext = self.label
-      if (self.showvaluesinlabel):
-        if (self.round == 0):
-          value = str(int(self.value))
-        else:
-          value = str(self.value)
-        labeltext = labeltext + ": " + value
-      glPushMatrix()
-      drawText( (0,0,1),(255,255,255), labeltext )
-      glPopMatrix()
+		if (self.showvalue):
+			glPushMatrix()
+			glTranslatef(self.w *0.5 , self.h *0.5 + Label_v_spacer *0.5 ,0)
+			drawText( (0,0,1), (128,0,255), str(round(self.value,2)))
+			glPopMatrix()
+		if (self.showlabel):
+			labeltext = self.label
+			if (self.showvaluesinlabel):
+				if (self.round == 0):
+					value = str(int(self.value))
+				else:
+					value = str(self.value)
+				labeltext = labeltext + ': ' + value
+			glPushMatrix()
+			drawText( (0,0,1),(255,255,255), labeltext )
+			glPopMatrix()
 
 
-    glPopMatrix()
-    pass
-#
-  def update(self):
-    pass
-  def setvalue(self,value):
-#
-    self.value = round(value, self.round )
-    #value
-    if (self.vmax - self.vmin) != 0:
-      self.percent = ((self.value + abs(self.vmin)) / float(self.vmax - self.vmin)) * 100
-    pass
+		glPopMatrix()
 
-  def update_mouse_move(self, mpx, mpy ):
-    self.mousepos[0] = mpx - self.x
-    self.mousepos[1] = mpy
-    if (self.mousegrab == 1):
-      self.percent = (self.mousepos[0] / self.w) * 100.0
+	def update(self) -> None:
+		pass
 
-      if ( self.percent > 100.0 ) : self.percent = 100
-      if ( self.percent < 0 ) : self.percent = 0
-      if (self.vmax-self.vmin) == 0:
-        self.value = 0
-      else:
-        self.value = round( self.percent * (self.vmax-self.vmin) * 0.01 + self.vmin, self.round )
-      if ( self.update_func != None ):
-        self.update_func(self, self.value)
-#      print "update_mouse_move on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y) + " value : " +str(self.value)
-#      if ( self.value > self.vmax ) : self.value = self.vmax
-#      if ( self.value < self.vmin ) : self.value = self.vmin
+	def setvalue(self, value) -> None:
+		self.value = round(value, self.round )
+		#value
+		if (self.vmax - self.vmin) != 0:
+			self.percent = ((self.value + abs(self.vmin)) / float(self.vmax - self.vmin)) * 100
 
-    pass
+	def update_mouse_move(self, mpx, mpy) -> None:
+		self.mousepos[0] = mpx - self.x
+		self.mousepos[1] = mpy
+		if (self.mousegrab == 1):
+			self.percent = (self.mousepos[0] / self.w) * 100.0
 
-  def update_mouse_down(self,mpx,mpy,btn):
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
-    #print "update_mouse_down on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y)
+			if ( self.percent > 100.0 ) : self.percent = 100
+			if ( self.percent < 0 ) : self.percent = 0
+			if (self.vmax-self.vmin) == 0:
+				self.value = 0
+			else:
+				self.value = round( self.percent * (self.vmax-self.vmin) * 0.01 + self.vmin, self.round )
+			if ( self.update_func != None ):
+				self.update_func(self, self.value)
+#			print "update_mouse_move on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y) + " value : " +str(self.value)
+#			if ( self.value > self.vmax ) : self.value = self.vmax
+#			if ( self.value < self.vmin ) : self.value = self.vmin
 
-    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-        #print "update_mouse_down grab on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y)
-        self.mousegrab = 1
-    self.update()
-    pass
+	def update_mouse_down(self,mpx, mpy, btn) -> None:
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
+		#print "update_mouse_down on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y)
 
-  def update_mouse_up(self,mpx,mpy,btn):
-    self.mousegrab = 0
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
-    #print "update_mouse_up on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y)
-    pass
+		if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
+				( mpy > self.y ) and ( mpy < self.y+self.h )):
+				#print "update_mouse_down grab on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y)
+				self.mousegrab = 1
+		self.update()
 
-  def update_key_down(self, keycode ):
-    pass
+	def update_mouse_up(self,mpx, mpy, btn) -> None:
+		self.mousegrab = 0
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
+		#print "update_mouse_up on slider x:" + str( mpx ) + " y:" + str(mpy) + " self.x:" + str( self.x ) + " self.y:" + str(self.y)
 
-  def update_key_up(self, keycode ):
-    pass
+	def update_key_down(self, keycode) -> None:
+		pass
+
+	def update_key_up(self, keycode) -> None:
+		pass
 
 class GLColorButton:
-  def __init__(self,x,y,w,h, index, color, onclick_procedure=None):
-    self.w = float(w)
-    self.h = float(h)
-    self.x = float(x)
-    self.y = float(y)
-    self.color = color
-    self.index = index
-    self.mousegrab = 0
-    self.mousepos = [0,0]
-    self.mouseclickpos = [0,0]
-    self.onclick_procedure = onclick_procedure
-    pass
+	def __init__(self,x,y,w,h, index, color, onclick_procedure=None) -> None:
+		self.w = float(w)
+		self.h = float(h)
+		self.x = float(x)
+		self.y = float(y)
+		self.color = color
+		self.index = index
+		self.mousegrab = 0
+		self.mousepos = [0,0]
+		self.mouseclickpos = [0,0]
+		self.onclick_procedure = onclick_procedure
 
-  def draw(self):
-    self.update()
-    glDisable(GL_TEXTURE_2D)
-    glEnable(GL_BLEND)
-    glPushMatrix()
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-    glColor4f(0.2, 0.2, 0.2, 0.9)
+	def draw(self) -> None:
+		self.update()
+		glDisable(GL_TEXTURE_2D)
+		glEnable(GL_BLEND)
+		glPushMatrix()
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		glColor4f(0.2, 0.2, 0.2, 0.9)
 
-    glTranslatef( self.x, self.y ,0)
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		glTranslatef( self.x, self.y ,0)
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 
-    if ( Gl.keyp_colormap_id == self.index ):
-      glColor4f(1.0, 1.0, 1.0, 1)
+		if ( Gl.keyp_colormap_id == self.index ):
+			glColor4f(1.0, 1.0, 1.0, 1)
 
-      DrawQuad(0,0,self.w,self.h)
-    else:
-      glColor4f(0.5, 0.5, 0.5, 1)
-      DrawQuad(2,2,self.w-2,self.h-2)
+			DrawQuad(0,0,self.w,self.h)
+		else:
+			glColor4f(0.5, 0.5, 0.5, 1)
+			DrawQuad(2,2,self.w-2,self.h-2)
 
-    glColor4f(0.0, 0.0, 0.0, 1)
-    DrawQuad(3,3,self.w-3,self.h-3)
+		glColor4f(0.0, 0.0, 0.0, 1)
+		DrawQuad(3,3,self.w-3,self.h-3)
 
-    glColor4ub(self.color[0],self.color[1],self.color[2], 255)
-    DrawQuad(5,5,self.w-5,self.h-5)
-    glPopMatrix()
-    pass
+		glColor4ub(self.color[0],self.color[1],self.color[2], 255)
+		DrawQuad(5,5,self.w-5,self.h-5)
+		glPopMatrix()
 
+	def update(self) -> None:
+		pass
 
-  def update(self):
-    pass
+	def update_mouse_move(self, mpx, mpy) -> None:
+		self.mousepos[0] = mpx
+		self.mousepos[1] = mpy
+		if (self.mousegrab == 1):
+			pass
 
-  def update_mouse_move(self, mpx, mpy ):
-    self.mousepos[0] = mpx
-    self.mousepos[1] = mpy
-    if (self.mousegrab == 1):
-      pass
-    pass
+	def update_mouse_down(self,mpx, mpy, btn) -> None:
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
+#		if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
+#				( mpy > self.y ) and ( mpy < self.y+self.h )):
+#				keyp_colormap_id = self.index
+#				print "color button: update_mouse_down set index = " + str(keyp_colormap_id)
 
-  def update_mouse_down(self,mpx,mpy,btn):
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
-#    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-#        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-#        keyp_colormap_id = self.index
-#        print "color button: update_mouse_down set index = " + str(keyp_colormap_id)
+		if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
+				( mpy > self.y ) and ( mpy < self.y+self.h )):
+				self.mousegrab = 1
+		self.update()
 
-    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-        self.mousegrab = 1
-    self.update()
-    pass
+	def update_mouse_up(self,mpx,mpy,btn) -> None:
+		self.mousegrab = 0
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
 
-  def update_mouse_up(self,mpx,mpy,btn):
-    self.mousegrab = 0
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
+		if (
+			( mpx > self.x ) and ( mpx < self.x+self.w ) and
+			( mpy > self.y ) and ( mpy < self.y+self.h )):
+				Gl.keyp_colormap_id = self.index
+#				if Gl.keyp_colormap_id < len(prefs.keyp_colors):
+				if self.onclick_procedure is not None:
+					self.onclick_procedure(self,self.index)
+#				print "color button: update_mouse_up set index = " + str(keyp_colormap_id)
 
-    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-        Gl.keyp_colormap_id = self.index
-#        if Gl.keyp_colormap_id < len(prefs.keyp_colors):
-        if self.onclick_procedure != None:
-          self.onclick_procedure(self,self.index)
-#        print "color button: update_mouse_up set index = " + str(keyp_colormap_id)
-    pass
+	def update_key_down(self, keycode) -> None:
+		pass
 
-  def update_key_down(self, keycode ):
-    pass
-
-  def update_key_up(self, keycode ):
-    pass
+	def update_key_up(self, keycode) -> None:
+		pass
 
 
 class GLButton:
-  def __init__(self,x,y,w,h, index, color = [128,128,128], text="", procedure=None, upcolor=[128,128,128], downcolor=[80,80,80], switch =0, switch_status =0, switch_on= [128,128,255], switch_off = [128,128,128], hint=""):
-    self.w = float(w)
-    self.h = float(h)
-    self.x = float(x)
-    self.y = float(y)
-    self.color = color
-    self.index = index
-    self.text = text
-    self.procedure = procedure
-    self.mousegrab = 0
-    self.mousepos = [0,0]
-    self.mouseclickpos = [0,0]
-    self.switch = switch
-    self.switch_status = switch_status
-    self.switch_on  = switch_on
-    self.switch_off = switch_off
-    self.downcolor = downcolor
-    self.upcolor = upcolor
-    self.hint = hint
-    self.mouse_over_time = 0
-    self.old_time = 0
-    pass
+	def __init__(self,x,y,w,h, index, color: list[int] = [128,128,128], text:str = '', procedure=None, upcolor=[128,128,128], downcolor=[80,80,80], switch:int = 0, switch_status:int = 0, switch_on= [128,128,255], switch_off = [128,128,128], hint: str = ''):
+		self.w = float(w)
+		self.h = float(h)
+		self.x = float(x)
+		self.y = float(y)
+		self.color = color
+		self.index = index
+		self.text = text
+		self.procedure = procedure
+		self.mousegrab = 0
+		self.mousepos = [0,0]
+		self.mouseclickpos = [0,0]
+		self.switch = switch
+		self.switch_status = switch_status
+		self.switch_on	= switch_on
+		self.switch_off = switch_off
+		self.downcolor = downcolor
+		self.upcolor = upcolor
+		self.hint = hint
+		self.mouse_over_time = 0
+		self.old_time = 0
 
-  def draw(self):
-    self.update()
-    glDisable(GL_TEXTURE_2D)
-    glEnable(GL_BLEND)
-    glPushMatrix()
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-    glColor4f(0.2, 0.2, 0.2, 0.9)
+	def draw(self) -> None:
+		self.update()
+		glDisable(GL_TEXTURE_2D)
+		glEnable(GL_BLEND)
+		glPushMatrix()
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		glColor4f(0.2, 0.2, 0.2, 0.9)
 
-    glTranslatef( self.x, self.y ,0)
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		glTranslatef( self.x, self.y ,0)
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 
-    glColor4f(0.5, 0.5, 0.5, 1)
-    DrawQuad(1,1,self.w-1,self.h-1)
+		glColor4f(0.5, 0.5, 0.5, 1)
+		DrawQuad(1,1,self.w-1,self.h-1)
 
-    glColor4f(1.0, 1.0, 1.0, 1)
-    DrawQuad(2,2,self.w-2,self.h-2)
-    if (self.switch) and (self.mousegrab == 0):
-      if self.switch_status:
-        self.color = self.switch_on
-      else:
-        self.color = self.switch_off
-    #
-    glColor4ub(self.color[0],self.color[1],self.color[2], 255)
-    DrawQuad(3,3,self.w-3,self.h-3)
-    glPopMatrix()
+		glColor4f(1.0, 1.0, 1.0, 1)
+		DrawQuad(2,2,self.w-2,self.h-2)
+		if (self.switch) and (self.mousegrab == 0):
+			if self.switch_status:
+				self.color = self.switch_on
+			else:
+				self.color = self.switch_off
 
-    glPushMatrix()
-    glTranslatef( self.x+5, self.y ,0)
-    glColor4f(1.0, 1.0, 1, 0.0)
-    #glScalef(0.7,0.7,0.7)
-    r = self.text.splitlines()
-    for i in r:
-      drawText( (0,Label_v_spacer,1),(255,255,255), i)
-      glTranslatef(0,Label_v_spacer,0)
-    glPopMatrix()
-    pass
+		glColor4ub(self.color[0],self.color[1],self.color[2], 255)
+		DrawQuad(3,3,self.w-3,self.h-3)
+		glPopMatrix()
 
-  def drawhint(self):
-    if self.hint:
-      if self.mouse_over_time > 1.5:
-#        drawHint(self.x + self.w *0.25,self.y,self.hint)
-        drawHint(self.mousepos[0],self.mousepos[1]-10,self.hint,True)
+		glPushMatrix()
+		glTranslatef( self.x+5, self.y ,0)
+		glColor4f(1.0, 1.0, 1, 0.0)
+		#glScalef(0.7,0.7,0.7)
+		r = self.text.splitlines()
+		for i in r:
+			drawText( (0,Label_v_spacer,1),(255,255,255), i)
+			glTranslatef(0,Label_v_spacer,0)
+		glPopMatrix()
+
+	def drawhint(self) -> None:
+		if self.hint and self.mouse_over_time > 1.5:
+#			drawHint(self.x + self.w *0.25,self.y,self.hint)
+			drawHint(self.mousepos[0],self.mousepos[1]-10,self.hint,True)
 
 
 
 
-  def update(self):
-    pass
+	def update(self) -> None:
+		pass
 
-  def update_mouse_move(self, mpx, mpy ):
-    self.mousepos[0] = mpx
-    self.mousepos[1] = mpy
-    px = mpx
-    py = mpy
-    #if self.hint:
-    #  print(self.hint, self.x, self.y, self.x + self.w, self.y + self.h, px,py)
-    if (( px > self.x ) and ( px < self.x+self.w ) and
-        ( py > self.y ) and ( py < self.y+self.h )):
-        if self.hint:
-          t1 = time.time()
-          self.mouse_over_time = t1 - self.old_time
-          #print(self.hint,self.mouse_over_time)
-    else:
-      if self.hint !="":
-        self.old_time = time.time()
-        self.mouse_over_time = 0
+	def update_mouse_move(self, mpx, mpy) -> None:
+		self.mousepos[0] = mpx
+		self.mousepos[1] = mpy
+		px = mpx
+		py = mpy
+		#if self.hint:
+		#	print(self.hint, self.x, self.y, self.x + self.w, self.y + self.h, px,py)
+		if (( px > self.x ) and ( px < self.x+self.w ) and
+				( py > self.y ) and ( py < self.y+self.h )):
+				if self.hint:
+					t1 = time.time()
+					self.mouse_over_time = t1 - self.old_time
+					#print(self.hint,self.mouse_over_time)
+		elif self.hint != '':
+			self.old_time = time.time()
+			self.mouse_over_time = 0
 
-    if (self.mousegrab == 1):
-      pass
+		if (self.mousegrab == 1):
+			pass
 
-    #self.mouse_over_time = self.mouse_over_time +
-    pass
+		#self.mouse_over_time = self.mouse_over_time +
 
-  def update_mouse_down(self,mpx,mpy,btn):
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
-#    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-#        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-#        keyp_colormap_id = self.index
-#        print "color button: update_mouse_down set index = " + str(keyp_colormap_id)
+	def update_mouse_down(self,mpx,mpy,btn) -> None:
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
+#		if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
+#				( mpy > self.y ) and ( mpy < self.y+self.h )):
+#				keyp_colormap_id = self.index
+#				print "color button: update_mouse_down set index = " + str(keyp_colormap_id)
 
-    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-        self.mousegrab = 1
-        self.color = self.downcolor
-    self.update()
-    pass
+		if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
+				( mpy > self.y ) and ( mpy < self.y+self.h )):
+				self.mousegrab = 1
+				self.color = self.downcolor
+		self.update()
 
-  def update_mouse_up(self,mpx,mpy,btn):
-    self.mousegrab = 0
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
+	def update_mouse_up(self,mpx, mpy, btn) -> None:
+		self.mousegrab = 0
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
 
-    if (( mpx > self.x ) and ( mpx < self.x+self.w ) and
-        ( mpy > self.y ) and ( mpy < self.y+self.h )):
-        self.color = self.upcolor
-        if (self.switch):
-          self.switch_status = not self.switch_status
-        self.procedure(self)
-        #keyp_colormap_id = self.index
-#        print "color button: update_mouse_up set index = " + str(keyp_colormap_id)
-    pass
+		if (
+			( mpx > self.x ) and ( mpx < self.x+self.w ) and
+			( mpy > self.y ) and ( mpy < self.y+self.h )):
+				self.color = self.upcolor
+				if (self.switch):
+					self.switch_status = not self.switch_status
+				self.procedure(self)
+				#keyp_colormap_id = self.index
+#				print "color button: update_mouse_up set index = " + str(keyp_colormap_id)
 
-  def update_key_down(self, keycode ):
-    pass
+	def update_key_down(self, keycode) -> None:
+		pass
 
-  def update_key_up(self, keycode ):
-    pass
+	def update_key_up(self, keycode) -> None:
+		pass
 
 class GLLabel:
-  def __init__(self,x,y,text):
-    self.x = x
-    self.y = y
-    self.text = text
-    pass
+	def __init__(self,x, y, text) -> None:
+		self.x = x
+		self.y = y
+		self.text = text
 
-  def draw(self):
-    self.update()
-    glPushMatrix()
-    glTranslatef(self.x,self.y,0)
-    glColor4f(1.0, 1.0, 1, 0.0)
-    r = self.text.splitlines()
-    for i in r:
-      drawText( (0,Label_v_spacer,1),(255,255,255), i)
-      glTranslatef(0,Label_v_spacer,0)
-    glPopMatrix()
-    pass
+	def draw(self) -> None:
+		self.update()
+		glPushMatrix()
+		glTranslatef(self.x,self.y,0)
+		glColor4f(1.0, 1.0, 1, 0.0)
+		r = self.text.splitlines()
+		for i in r:
+			drawText( (0,Label_v_spacer,1),(255,255,255), i)
+			glTranslatef(0,Label_v_spacer,0)
+		glPopMatrix()
 
-  def update(self):
-    pass
-  def update_mouse_move(self, mpx, mpy ):
-    pass
-  def update_mouse_down(self,mpx, mpy, btn):
-    pass
-  def update_mouse_up(self, mpx, mpy, btn):
-    pass
-  def update_key_down(self, keycode ):
-    pass
-  def update_key_up(self, keycode ):
-    pass
+	def update(self) -> None:
+		pass
+	def update_mouse_move(self, mpx, mpy) -> None:
+		pass
+	def update_mouse_down(self,mpx, mpy, btn) -> None:
+		pass
+	def update_mouse_up(self, mpx, mpy, btn) -> None:
+		pass
+	def update_key_down(self, keycode) -> None:
+		pass
+	def update_key_up(self, keycode) -> None:
+		pass
 
 class GLWindow:
-  def __init__(self,x,y,w,h,title):
-    self.w = w
-    self.h = h
-    self.x = x
-    self.y = y
-    self.borderwidth=2
-    self.title = title
-    self.titleheight = 25
-    self.titlewidth = self.w
-    self.clientrect=[0,0,0,0]
-    self.mousegrab = 0
-    self.mousepos = [0,0]
-    self.mouseclickpos = [0,0]
-    self.hidden = 0
-    self.fullhidden = 0
-    self.child = []
-    self.level = 0
-    self.active = 0
-    #
-    self.clientrect[0] = self.x + self.borderwidth
-    self.clientrect[1] = self.y + self.borderwidth + self.titleheight
-    self.clientrect[2] = self.x + self.w - self.borderwidth
-    self.clientrect[3] = self.y + self.h - self.titleheight - self.borderwidth
-    #
-  def appendChild(self,child):
-    self.child.append(child)
+	def __init__(self,x,y,w,h,title) -> None:
+		self.w = w
+		self.h = h
+		self.x = x
+		self.y = y
+		self.borderwidth=2
+		self.title = title
+		self.titleheight = 25
+		self.titlewidth = self.w
+		self.clientrect=[0,0,0,0]
+		self.mousegrab = 0
+		self.mousepos = [0,0]
+		self.mouseclickpos = [0,0]
+		self.hidden = 0
+		self.fullhidden = 0
+		self.child = []
+		self.level = 0
+		self.active = 0
 
-  def draw(self):
-    if self.fullhidden:
-      return
-    self.update()
-    glDisable(GL_TEXTURE_2D)
-    glEnable(GL_BLEND)
-    glPushMatrix()
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-    if self.active == 1:
-      glColor4f(0.3, 0.3, 0.3, 0.9)
-    else:
-      glColor4f(0.2, 0.2, 0.2, 0.9)
-    DrawQuad(self.x,self.y,self.x+self.w,self.y+self.titleheight)
-    if ( not self.hidden ):
-      glColor4f(0.1, 0.1, 0.1, 0.9)
-      DrawQuad(self.x,self.y+self.titleheight,self.x+self.titlewidth,self.y+self.h-self.titleheight)
-    glColor4f(1.0, 1.0, 1.0, 0.9)
-    DrawTriangle(self.x+self.titlewidth-16,self.y+18,10, self.hidden)
+		self.clientrect[0] = self.x + self.borderwidth
+		self.clientrect[1] = self.y + self.borderwidth + self.titleheight
+		self.clientrect[2] = self.x + self.w - self.borderwidth
+		self.clientrect[3] = self.y + self.h - self.titleheight - self.borderwidth
 
-    glColor4f(0.0, 0.0, 0.0, 0.9)
-    DrawRect(self.x,self.y,self.x+self.w,self.y+self.titleheight)
-    if ( not self.hidden ):
-      glColor4f(0.1, 0.1, 0.1, 0.9)
-      DrawRect(self.x,self.y+self.titleheight,self.x+self.w,self.y+self.h-self.titleheight)
+	def appendChild(self, child) -> None:
+		self.child.append(child)
 
-    glBlendFunc(GL_ONE, GL_SRC_ALPHA)
-    drawText( (self.x+4,self.y+self.titleheight-2,1),(255,255,255), self.title )
-    glTranslatef(self.clientrect[0],self.clientrect[1],0)
-    if ( not self.hidden ):
-      for i in self.child:
-        if hasattr(i, 'draw'):
-          i.draw()
+	def draw(self) -> None:
+		if self.fullhidden:
+			return
+		self.update()
+		glDisable(GL_TEXTURE_2D)
+		glEnable(GL_BLEND)
+		glPushMatrix()
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+		if self.active == 1:
+			glColor4f(0.3, 0.3, 0.3, 0.9)
+		else:
+			glColor4f(0.2, 0.2, 0.2, 0.9)
+		DrawQuad(self.x,self.y,self.x+self.w,self.y+self.titleheight)
+		if ( not self.hidden ):
+			glColor4f(0.1, 0.1, 0.1, 0.9)
+			DrawQuad(self.x,self.y+self.titleheight,self.x+self.titlewidth,self.y+self.h-self.titleheight)
+		glColor4f(1.0, 1.0, 1.0, 0.9)
+		DrawTriangle(self.x+self.titlewidth-16,self.y+18,10, self.hidden)
 
-    glPopMatrix()
-    glDisable(GL_BLEND)
+		glColor4f(0.0, 0.0, 0.0, 0.9)
+		DrawRect(self.x,self.y,self.x+self.w,self.y+self.titleheight)
+		if ( not self.hidden ):
+			glColor4f(0.1, 0.1, 0.1, 0.9)
+			DrawRect(self.x,self.y+self.titleheight,self.x+self.w,self.y+self.h-self.titleheight)
 
-    pass
+		glBlendFunc(GL_ONE, GL_SRC_ALPHA)
+		drawText( (self.x+4,self.y+self.titleheight-2,1),(255,255,255), self.title )
+		glTranslatef(self.clientrect[0],self.clientrect[1],0)
+		if ( not self.hidden ):
+			for i in self.child:
+				if hasattr(i, 'draw'):
+					i.draw()
 
-  def drawhint(self):
-    if ( self.hidden ) or ( self.fullhidden ) or ( self.active <1 ) :
-      return
-    glPushMatrix()
-    glTranslatef( self.x, self.y +self.titleheight,0)
-    for i in self.child:
-      if hasattr(i, 'drawhint'):
-        i.drawhint()
-    glPopMatrix()
+		glPopMatrix()
+		glDisable(GL_BLEND)
 
-  def update(self):
-    if self.fullhidden:
-      return
+	def drawhint(self) -> None:
+		if ( self.hidden ) or ( self.fullhidden ) or ( self.active <1 ) :
+			return
+		glPushMatrix()
+		glTranslatef( self.x, self.y +self.titleheight,0)
+		for i in self.child:
+			if hasattr(i, 'drawhint'):
+				i.drawhint()
+		glPopMatrix()
 
-    self.titlewidth = self.w
+	def update(self) -> None:
+		if self.fullhidden:
+			return
 
-    self.clientrect[0] = self.x + self.borderwidth
-    self.clientrect[1] = self.y + self.borderwidth + self.titleheight
-    self.clientrect[2] = self.x + self.w - self.borderwidth
-    self.clientrect[3] = self.y + self.h - self.titleheight - self.borderwidth
+		self.titlewidth = self.w
 
-    if ( not self.hidden ):
-      for i in self.child:
-        if hasattr(i, 'update'):
-          i.update()
+		self.clientrect[0] = self.x + self.borderwidth
+		self.clientrect[1] = self.y + self.borderwidth + self.titleheight
+		self.clientrect[2] = self.x + self.w - self.borderwidth
+		self.clientrect[3] = self.y + self.h - self.titleheight - self.borderwidth
 
-    pass
+		if ( not self.hidden ):
+			for i in self.child:
+				if hasattr(i, 'update'):
+					i.update()
 
-  def getclientrect(self):
-    self.update()
-    return self.clientrect
+	def getclientrect(self) -> list[int]:
+		self.update()
+		return self.clientrect
 
-  def update_mouse_move(self, mpx, mpy ):
-    if self.fullhidden:
-      return
+	def update_mouse_move(self, mpx, mpy) -> None:
+		if self.fullhidden:
+			return
 
-    self.mousepos[0] = mpx
-    self.mousepos[1] = mpy
+		self.mousepos[0] = mpx
+		self.mousepos[1] = mpy
 
-    if (self.mousegrab == 1):
-      self.x = mpx - self.mouseclickpos[0]
-      self.y = mpy - self.mouseclickpos[1]
+		if (self.mousegrab == 1):
+			self.x = mpx - self.mouseclickpos[0]
+			self.y = mpy - self.mouseclickpos[1]
 
-    if ( not self.hidden ):
-      for i in self.child:
-        if hasattr(i, 'update_mouse_move'):
-          i.update_mouse_move(mpx - self.x,mpy - self.y- self.titleheight)
+		if ( not self.hidden ):
+			for i in self.child:
+				if hasattr(i, 'update_mouse_move'):
+					i.update_mouse_move(mpx - self.x,mpy - self.y- self.titleheight)
 
-    pass
+	def update_mouse_down(self,mpx, mpy, btn) -> int:
+		if self.fullhidden:
+			return 0
 
-  def update_mouse_down(self,mpx,mpy,btn):
-    if self.fullhidden:
-      return 0
-
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
-    self.active = 0
-    if ( not self.hidden ):
-      if (( mpx > self.x ) and ( mpx < self.x + self.w ) and
-          ( mpy > self.y ) and ( mpy < self.y + self.h - self.titleheight )):
-          self.active = 1
-      else:
-          self.active = 0
-    else:
-      if (( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
-        ( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
-          self.active = 1
-      else:
-          self.active = 0
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
+		self.active = 0
+		if ( not self.hidden ):
+			if (
+				( mpx > self.x ) and ( mpx < self.x + self.w ) and
+				( mpy > self.y ) and ( mpy < self.y + self.h - self.titleheight )):
+					self.active = 1
+			else:
+					self.active = 0
+		elif (
+			( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
+			( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
+				self.active = 1
+		else:
+				self.active = 0
 
 
-    if (( mpx > self.x+self.titlewidth-16 ) and ( mpx < self.x + self.w ) and
-        ( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
-        self.hidden = not self.hidden
-        return self.hidden
+		if (
+			( mpx > self.x+self.titlewidth-16 ) and ( mpx < self.x + self.w ) and
+			( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
+				self.hidden = not self.hidden
+				return self.hidden
 
 
-    if (( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
-        ( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
-        self.mousegrab = 1
+		if (
+			( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
+			( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
+				self.mousegrab = 1
 
-    if ( not self.hidden ) and ( not self.mousegrab ):
-      for i in self.child:
-        if hasattr(i, 'update_mouse_down'):
-          i.update_mouse_down(mpx - self.clientrect[0],mpy - self.clientrect[1],btn)
+		if ( not self.hidden ) and ( not self.mousegrab ):
+			for i in self.child:
+				if hasattr(i, 'update_mouse_down'):
+					i.update_mouse_down(mpx - self.clientrect[0],mpy - self.clientrect[1],btn)
 
-    self.update()
-    return self.active
-    pass
-
-
-  def update_mouse_up(self,mpx,mpy,btn):
-    self.mousegrab = 0
-    self.mouseclickpos[0] = mpx - self.x
-    self.mouseclickpos[1] = mpy - self.y
-
-    if ( not self.hidden ):
-      if (( mpx > self.x ) and ( mpx < self.x + self.w ) and
-          ( mpy > self.y ) and ( mpy < self.y + self.h - self.titleheight )):
-          self.active = 1
-      else:
-          self.active = 0
-    else:
-      if (( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
-        ( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
-          self.active = 1
-      else:
-          self.active = 0
-
-    if ( not self.hidden ):
-      for i in self.child:
-        if hasattr(i, 'update_mouse_up'):
-          i.update_mouse_up(mpx - self.clientrect[0],mpy - self.clientrect[1] ,btn)
-    return self.active
-
-  def update_key_down(self, keycode ):
-    if self.fullhidden:
-      return 0
-
-    mpx = self.mousepos[0]
-    mpy = self.mousepos[1]
+		self.update()
+		return self.active
 
 
-    if not self.hidden:
-      if (( mpx > self.x ) and ( mpx < self.x + self.w ) and
-          ( mpy > self.y ) and ( mpy < self.y + self.h - self.titleheight)):
-        if keycode == pygame.K_h:
-          self.hidden = not self.hidden
-    else:
-      if (( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
-          ( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
-        if keycode == pygame.K_h:
-          self.hidden = not self.hidden
+	def update_mouse_up(self,mpx, mpy, btn):
+		self.mousegrab = 0
+		self.mouseclickpos[0] = mpx - self.x
+		self.mouseclickpos[1] = mpy - self.y
 
-    if ( not self.hidden ):
-      for i in self.child:
-        if hasattr(i, 'update_key_down'):
-          i.update_key_down(keycode)
+		if ( not self.hidden ):
+			if (
+				( mpx > self.x ) and ( mpx < self.x + self.w ) and
+				( mpy > self.y ) and ( mpy < self.y + self.h - self.titleheight )):
+					self.active = 1
+			else:
+					self.active = 0
+		elif (
+			( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
+			( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
+				self.active = 1
+		else:
+				self.active = 0
 
-    pass
-  def update_key_up(self, keycode ):
-    if self.fullhidden:
-      return 0
+		if ( not self.hidden ):
+			for i in self.child:
+				if hasattr(i, 'update_mouse_up'):
+					i.update_mouse_up(mpx - self.clientrect[0],mpy - self.clientrect[1] ,btn)
+		return self.active
 
-    if ( not self.hidden ):
-      for i in self.child:
-        if hasattr(i, 'update_key_up'):
-          i.update_key_up(keycode)
-    pass
+	def update_key_down(self, keycode ) -> int | None:
+		if self.fullhidden:
+			return 0
+
+		mpx = self.mousepos[0]
+		mpy = self.mousepos[1]
+
+
+		if not self.hidden:
+			if (
+				( mpx > self.x ) and ( mpx < self.x + self.w ) and
+				( mpy > self.y ) and ( mpy < self.y + self.h - self.titleheight)):
+				if keycode == pygame.K_h:
+					self.hidden = not self.hidden
+		else:
+			if (
+				( mpx > self.x ) and ( mpx < self.x + self.titlewidth ) and
+				( mpy > self.y ) and ( mpy < self.y + self.titleheight )):
+				if keycode == pygame.K_h:
+					self.hidden = not self.hidden
+
+		if ( not self.hidden ):
+			for i in self.child:
+				if hasattr(i, 'update_key_down'):
+					i.update_key_down(keycode)
+
+	def update_key_up(self, keycode) -> int | None:
+		if self.fullhidden:
+			return 0
+
+		if ( not self.hidden ):
+			for i in self.child:
+				if hasattr(i, 'update_key_up'):
+					i.update_key_up(keycode)

--- a/video2midi/gl.py
+++ b/video2midi/gl.py
@@ -11,7 +11,7 @@ from .prefs import prefs
 
 Label_v_spacer=21
 fontSize=24
-fontChars = u''' !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz><'''
+fontChars = ''' !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz><'''
 
 class Gl:
 	fontTexture = -1

--- a/video2midi/gl.py
+++ b/video2midi/gl.py
@@ -245,9 +245,10 @@ def GenFontTexture() -> None:
 		fonts.append( fnt )
 
 		x += ix + 2
-		if (i % 32 == 31 ) and (i != 0): x=2
+		if (i % 32 == 31 ) and (i != 0):
+			x = 2
 
-	tex_data = pygame.image.tostring(texture_buffer_surf, "RGBA", 1)
+	tex_data = pygame.image.tostring(texture_buffer_surf, 'RGBA', True)
 
 	# fix alpha ...
 	l = list( tex_data )

--- a/video2midi/midi.py
+++ b/video2midi/midi.py
@@ -1,78 +1,79 @@
-from midiutil.MidiFile import MIDIFile
 import os
 
+from midiutil.MidiFile import MIDIFile
+
+
 class midinotes:
-  def __init__(self, midi_file_format):
-    self.debug = 0
-    self.notes = []
-    self.miditrackname = "Sample Track"
-    self.tempo = 0
-    self.track = 0
-    self.midi_file_format = int(midi_file_format)
-    print("initialize midifile...")
-    self.mf = MIDIFile(1,file_format=self.midi_file_format,
-          removeDuplicates=True,
-          deinterleave=False,
-          adjust_origin=False)
-    print("initialize midifile done.")
+	def __init__(self, midi_file_format) -> None:
+		self.debug = 0
+		self.notes = []
+		self.miditrackname = 'Sample Track'
+		self.tempo = 0
+		self.track = 0
+		self.midi_file_format = int(midi_file_format)
+		print('initialize midifile...')
+		self.mf = MIDIFile(1,file_format=self.midi_file_format,
+					removeDuplicates=True,
+					deinterleave=False,
+					adjust_origin=False)
+		print('initialize midifile done.')
 
-  def addNote(self,track, channel, note, start_time, duration, volume ):
-    self.notes.append( {'track' : track, 'channel' : channel, 'note' : note, 'start_time' : start_time, 'duration' : duration, 'volume' : volume } )
+	def addNote(self, track, channel, note, start_time, duration, volume):
+		self.notes.append( {'track' : track, 'channel' : channel, 'note' : note, 'start_time' : start_time, 'duration' : duration, 'volume' : volume } )
 
-  def sync_start_pos(self, time_delta = 0.25, abs_time_delta=False ):
-    for i in range( len(self.notes) ):
-      for j in range( i+1, len(self.notes) ):
-        if abs_time_delta:
-          if abs(self.notes[j]['start_time'] - self.notes[i]['start_time']) < time_delta:
-            self.notes[j]['start_time'] = self.notes[i]['start_time']
-        else:
-          if self.notes[j]['start_time'] - self.notes[i]['start_time'] < time_delta:
-            self.notes[j]['start_time'] = self.notes[i]['start_time']
+	def sync_start_pos(self, time_delta: float = 0.25, abs_time_delta: bool = False):
+		for i in range( len(self.notes) ):
+			for j in range( i+1, len(self.notes) ):
+				if abs_time_delta:
+					if abs(self.notes[j]['start_time'] - self.notes[i]['start_time']) < time_delta:
+						self.notes[j]['start_time'] = self.notes[i]['start_time']
+				elif self.notes[j]['start_time'] - self.notes[i]['start_time'] < time_delta:
+					self.notes[j]['start_time'] = self.notes[i]['start_time']
 
-  def setup_track(self, time, trackName, tempo ):
-    self.miditrackname = trackName
-    self.tempo = tempo
-    self.mf.addTrackName(self.track, time, trackName)
-    self.mf.addTempo(self.track, time, tempo )
+	def setup_track(self, time, trackName, tempo ):
+		self.miditrackname = trackName
+		self.tempo = tempo
+		self.mf.addTrackName(self.track, time, trackName)
+		self.mf.addTempo(self.track, time, tempo )
 
-  def addProgramChange(self, track, channel, program):
-    self.mf.addProgramChange(track, channel, 0, program)
+	def addProgramChange(self, track, channel, program):
+		self.mf.addProgramChange(track, channel, 0, program)
 
-  def save_to_disk(self, filename):
-    if len(self.notes) < 1:
-      return 0, "No notes to save.."
-    for i in self.notes:
-      self.mf.addNote( i['track'], i['channel'], i['note'], i['start_time'], i['duration'], i['volume'] )
-    try:
-      with open(filename, 'wb') as outf:
-        self.mf.writeFile(outf)
-    except Exception as E:
-      print("Error on save to disk:%s"% E)
-      return -1, "Can't save to disk:%s" % filename
-    return 1, "Saved to disk:%s" % filename
+	def save_to_disk(self, filename: str) -> tuple[int, str]:
+		if len(self.notes) < 1:
+			return 0, 'No notes to save..'
+		for i in self.notes:
+			self.mf.addNote( i['track'], i['channel'], i['note'], i['start_time'], i['duration'], i['volume'] )
+		try:
+			with open(filename, 'wb') as outf:
+				self.mf.writeFile(outf)
+		except Exception as E:
+			print(f'Error on save to disk:{E}')
+			return -1, f"Can't save to disk:{filename}"
+		return 1, f'Saved to disk:{filename}'
 
-  def save_to_disk_per_channel(self, filename):
-    if len(self.notes) < 1:
-      return 0, "No notes to save.."
-    fname,ext =os.path.splitext(filename)
-    for channel in range(16):
-      cnt=0
-      #
-      print( " processing channel %s"  % channel )
-      self.mf = MIDIFile(1,file_format=self.midi_file_format)
-      self.mf.addTrackName(self.track, 0, "%s channel=%s " % (self.miditrackname, channel+1 ))
-      self.mf.addTempo(self.track, 0, self.tempo )
-      self.mf.addProgramChange(0, channel, 0, 0)
-      for i in self.notes:
-        if i['channel'] == channel:
-          self.mf.addNote( i['track'], i['channel'], i['note'], i['start_time'], i['duration'], i['volume'] )
-          cnt+=1
-      #
-      if cnt >0:
-        try:
-          with open("%s_channel_%s%s" % (fname,channel+1,ext), 'wb') as outf:
-            self.mf.writeFile(outf)
-        except Exception as E:
-          print("Error on save to disk:%s"% E)
-      #
-    return 1, "Saved to disk: %s_channel_[1..16]%s " % (fname,ext)
+	def save_to_disk_per_channel(self, filename: str) -> tuple[int, str]:
+		if len(self.notes) < 1:
+			return 0, 'No notes to save..'
+		fname,ext = os.path.splitext(filename)
+		for channel in range(16):
+			cnt=0
+
+			print( f' processing channel {channel}' )
+			self.mf = MIDIFile(1,file_format=self.midi_file_format)
+			self.mf.addTrackName(self.track, 0, f'{self.miditrackname} channel={channel+1} ')
+			self.mf.addTempo(self.track, 0, self.tempo )
+			self.mf.addProgramChange(0, channel, 0, 0)
+			for i in self.notes:
+				if i['channel'] == channel:
+					self.mf.addNote( i['track'], i['channel'], i['note'], i['start_time'], i['duration'], i['volume'] )
+					cnt+=1
+
+			if cnt >0:
+				try:
+					with open(f'{fname}_channel_{channel+1}{ext}', 'wb') as outf:
+						self.mf.writeFile(outf)
+				except Exception as E:
+					print(f'Error on save to disk:{E}')
+
+		return 1, f'Saved to disk: {fname}_channel_[1..16]{ext} '

--- a/video2midi/prefs.py
+++ b/video2midi/prefs.py
@@ -26,7 +26,7 @@ class prefs:
 	rollcheck = False
 	rollcheck_priority = 0
 
-	keyp_colors_channel =	  [ 0,0, 1,1, 2,2, 3,3, 4,4, 5,5, 6,6, 7,7, 8,8, 9,9, 10,10, 11,11 ] # MIDI channel per color
+	keyp_colors_channel =      [ 0,0, 1,1, 2,2, 3,3, 4,4, 5,5, 6,6, 7,7, 8,8, 9,9, 10,10, 11,11 ] # MIDI channel per color
 	keyp_colors_channel_prog = [ 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0,  0, 0,  0, 0 ] # MIDI program ID per channel
 
 	xoffset_whitekeys = 60

--- a/video2midi/prefs.py
+++ b/video2midi/prefs.py
@@ -1,72 +1,71 @@
 
 class prefs:
-    debug = 0
-    miditrackname="Sample Track"
-    notes_overlap = False
+	debug = 0
+	miditrackname='Sample Track'
+	notes_overlap = False
 
-    resize= 0
-    resize_width=1280
-    resize_height=720
+	resize= 0
+	resize_width=1280
+	resize_height=720
 
-    minimal_duration = 0.1
-    ignore_minimal_duration = False
+	minimal_duration = 0.1
+	ignore_minimal_duration = False
 
-    keyp_delta = 90 # sensitivity
+	keyp_delta = 90 # sensitivity
 
-    octave = 3
-    tempo = 120
-    startframe = 1
+	octave = 3
+	tempo = 120
+	startframe = 1
 
-    blackkey_relative_position = 0.4
+	blackkey_relative_position = 0.4
 
-    keyp_spark_y_pos = -110
-    use_sparks= False
+	keyp_spark_y_pos = -110
+	use_sparks= False
 
-    use_alternate_keys = False
-    rollcheck = False
-    rollcheck_priority = 0
+	use_alternate_keys = False
+	rollcheck = False
+	rollcheck_priority = 0
 
-    keyp_colors_channel =      [ 0,0, 1,1, 2,2, 3,3, 4,4, 5,5, 6,6, 7,7, 8,8, 9,9, 10,10, 11,11 ] # MIDI channel per color
-    keyp_colors_channel_prog = [ 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0,  0, 0,  0, 0 ] # MIDI program ID per channel
+	keyp_colors_channel =	  [ 0,0, 1,1, 2,2, 3,3, 4,4, 5,5, 6,6, 7,7, 8,8, 9,9, 10,10, 11,11 ] # MIDI channel per color
+	keyp_colors_channel_prog = [ 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0, 0,0,  0, 0,  0, 0 ] # MIDI program ID per channel
 
-    xoffset_whitekeys = 60
-    yoffset_whitekeys = 673
-    yoffset_blackkeys = -30
-    whitekey_width=24.6
+	xoffset_whitekeys = 60
+	yoffset_whitekeys = 673
+	yoffset_blackkeys = -30
+	whitekey_width=24.6
 
-    keyp_colors_alternate = []
-    keyp_colors_alternate_sensitivity = []
-    keyp_colors = [
-    #L.GREEN         D.GREEN
-    [166,250,103], [ 58,146,  0],
-    #L.BLUE          D.BLUE
-    [102,185,207], [  8,113,174],
-    #L.YELLOW        D.YELLOW
-    [255,255,85 ], [254,210,  0],
-    #L.ORANGE        D.ORANGE
-    [255,212,85 ], [255,138,  0],
-    #L.RED           D.RED
-    [253,125,114], [255, 37,  9],
-    #EMPTY
-    [0  ,  0,  0], [  0,  0,  0],
-    [0  ,  0,  0], [  0,  0,  0],
-    [0  ,  0,  0], [  0,  0,  0],
-    [0  ,  0,  0], [  0,  0,  0],
-    [0  ,  0,  0], [  0,  0,  0],
-    [0  ,  0,  0], [  0,  0,  0],
-    [0  ,  0,  0], [  0,  0,  0]
-    # .....
-    ]
-    keyp_colors_sparks_sensitivity = [50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50]
+	keyp_colors_alternate = []
+	keyp_colors_alternate_sensitivity = []
+	keyp_colors = [
+	#L.GREEN		 D.GREEN
+	[166,250,103], [ 58,146,  0],
+	#L.BLUE		  D.BLUE
+	[102,185,207], [  8,113,174],
+	#L.YELLOW		D.YELLOW
+	[255,255,85 ], [254,210,  0],
+	#L.ORANGE		D.ORANGE
+	[255,212,85 ], [255,138,  0],
+	#L.RED		   D.RED
+	[253,125,114], [255, 37,  9],
+	#EMPTY
+	[0  ,  0,  0], [  0,  0,  0],
+	[0  ,  0,  0], [  0,  0,  0],
+	[0  ,  0,  0], [  0,  0,  0],
+	[0  ,  0,  0], [  0,  0,  0],
+	[0  ,  0,  0], [  0,  0,  0],
+	[0  ,  0,  0], [  0,  0,  0],
+	[0  ,  0,  0], [  0,  0,  0],
+	]
+	keyp_colors_sparks_sensitivity = [50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50,50]
 
-    keys_pos=[]
-    keys_angle = 90
-    #
-    use_percolor_delta=False
-    #
-    percolor_delta=[90]*20
-    autoclose = 1
-    sync_notes_start_pos = False
-    sync_notes_start_pos_time_delta = 1000
-    save_to_disk_message = ""
-    save_to_disk_per_channel = False
+	keys_pos=[]
+	keys_angle = 90
+
+	use_percolor_delta=False
+
+	percolor_delta=[90]*20
+	autoclose = 1
+	sync_notes_start_pos = False
+	sync_notes_start_pos_time_delta = 1000
+	save_to_disk_message = ''
+	save_to_disk_per_channel = False

--- a/video2midi/settings.py
+++ b/video2midi/settings.py
@@ -1,249 +1,245 @@
-try:
-  from configparser import ConfigParser
-except ImportError:
-  from ConfigParser import ConfigParser  # ver. < 3.0
+
+import os
+from configparser import ConfigParser
 
 from video2midi.prefs import prefs
-import os
 
-def savesettings(settingsfile):
-  print("save settings to "+settingsfile)
-  config = ConfigParser()
-  section='options'
-  config.add_section(section)
-  config.set(section, 'midi_track_name', prefs.miditrackname)
-  config.set(section, 'debug', str(int(prefs.debug)))
-  config.set(section, 'notes_overlap', str(int(prefs.notes_overlap)))
-  config.set(section, 'resize', str(int(prefs.resize)))
-  config.set(section, 'resize_width', str(prefs.resize_width))
-  config.set(section, 'resize_height', str(prefs.resize_height))
-  config.set(section, 'minimal_note_duration', str(prefs.minimal_duration))
-  config.set(section, 'ignore_notes_with_minimal_duration', str(int(prefs.ignore_minimal_duration)))
-  config.set(section, 'sensitivity', str(int(prefs.keyp_delta)))
-  config.set(section, 'octave', str(int(prefs.octave)))
-  config.set(section, 'output_midi_tempo', str(int(prefs.tempo)))
-  config.set(section, 'frame_start', str(int(prefs.startframe)))
-  config.set(section, 'blackkey_relative_position', str(float(prefs.blackkey_relative_position)))
-  #Sparks
-  config.set(section, 'keyp_spark_y_pos', str(int(prefs.keyp_spark_y_pos)))
-  config.set(section, 'use_sparks', str( int(prefs.use_sparks) ))
-  # extra
-  config.set(section, 'rollcheck', str( int(prefs.rollcheck) ))
-  config.set(section, 'rollcheck_priority', str( int(prefs.rollcheck_priority) ))
-  config.set(section, 'use_alternate_keys', str( int(prefs.use_alternate_keys) ))
 
-  skeyp_colors_channel = ""
-  for i in prefs.keyp_colors_channel:
-    skeyp_colors_channel+= str(i)+","
-  skeyp_colors_channel_prog = ""
-  for i in prefs.keyp_colors_channel_prog:
-    skeyp_colors_channel_prog+= str(i)+","
-  config.set(section, 'color_channel_accordance',skeyp_colors_channel[0:-1])
-  config.set(section, 'channel_prog_accordance', skeyp_colors_channel_prog[0:-1])
+def savesettings(settingsfile: str) -> None:
+	print('save settings to '+settingsfile)
+	config = ConfigParser()
+	section='options'
+	config.add_section(section)
+	config.set(section, 'midi_track_name', prefs.miditrackname)
+	config.set(section, 'debug', str(int(prefs.debug)))
+	config.set(section, 'notes_overlap', str(int(prefs.notes_overlap)))
+	config.set(section, 'resize', str(int(prefs.resize)))
+	config.set(section, 'resize_width', str(prefs.resize_width))
+	config.set(section, 'resize_height', str(prefs.resize_height))
+	config.set(section, 'minimal_note_duration', str(prefs.minimal_duration))
+	config.set(section, 'ignore_notes_with_minimal_duration', str(int(prefs.ignore_minimal_duration)))
+	config.set(section, 'sensitivity', str(int(prefs.keyp_delta)))
+	config.set(section, 'octave', str(int(prefs.octave)))
+	config.set(section, 'output_midi_tempo', str(int(prefs.tempo)))
+	config.set(section, 'frame_start', str(int(prefs.startframe)))
+	config.set(section, 'blackkey_relative_position', str(float(prefs.blackkey_relative_position)))
+	# Sparks
+	config.set(section, 'keyp_spark_y_pos', str(int(prefs.keyp_spark_y_pos)))
+	config.set(section, 'use_sparks', str( int(prefs.use_sparks) ))
+	# extra
+	config.set(section, 'rollcheck', str( int(prefs.rollcheck) ))
+	config.set(section, 'rollcheck_priority', str( int(prefs.rollcheck_priority) ))
+	config.set(section, 'use_alternate_keys', str( int(prefs.use_alternate_keys) ))
 
-  config.set(section, 'xoffset_whitekeys',str(int(prefs.xoffset_whitekeys)))
-  config.set(section, 'yoffset_whitekeys',str(int(prefs.yoffset_whitekeys)))
-  config.set(section, 'yoffset_blackkeys',str(int(prefs.yoffset_blackkeys)))
-  config.set(section, 'whitekey_width',str(int(prefs.whitekey_width)))
+	skeyp_colors_channel = ''
+	for i in prefs.keyp_colors_channel:
+		skeyp_colors_channel+= str(i)+','
+	skeyp_colors_channel_prog = ''
+	for i in prefs.keyp_colors_channel_prog:
+		skeyp_colors_channel_prog+= str(i)+','
+	config.set(section, 'color_channel_accordance',skeyp_colors_channel[0:-1])
+	config.set(section, 'channel_prog_accordance', skeyp_colors_channel_prog[0:-1])
 
-  skeyp_colors=""
-  for i in prefs.keyp_colors:
-    skeyp_colors+= str(int(i[0]))+":"+str(int(i[1]))+":"+str(int(i[2]))+","
-  config.set(section, 'keyp_colors', skeyp_colors[0:-1])
+	config.set(section, 'xoffset_whitekeys',str(int(prefs.xoffset_whitekeys)))
+	config.set(section, 'yoffset_whitekeys',str(int(prefs.yoffset_whitekeys)))
+	config.set(section, 'yoffset_blackkeys',str(int(prefs.yoffset_blackkeys)))
+	config.set(section, 'whitekey_width',str(int(prefs.whitekey_width)))
 
-  skeyp_colors_sparks_sensitivity=""
-  for i in prefs.keyp_colors_sparks_sensitivity:
-    skeyp_colors_sparks_sensitivity += str(round(i,2))+","
-  config.set(section, 'keyp_colors_sparks_sensitivity', skeyp_colors_sparks_sensitivity[0:-1])
+	skeyp_colors=''
+	for i in prefs.keyp_colors:
+		skeyp_colors+= str(int(i[0]))+':'+str(int(i[1]))+':'+str(int(i[2]))+','
+	config.set(section, 'keyp_colors', skeyp_colors[0:-1])
 
-  spercolor_sensitivity=""
-  for i in prefs.percolor_delta:
-    spercolor_sensitivity += str(round(i,2))+","
-  config.set(section, 'percolor_sensitivity', spercolor_sensitivity[0:-1])
-  config.set(section, 'use_percolor_sensitivity', str( int(prefs.use_percolor_delta) ))
+	skeyp_colors_sparks_sensitivity=''
+	for i in prefs.keyp_colors_sparks_sensitivity:
+		skeyp_colors_sparks_sensitivity += str(round(i,2))+','
+	config.set(section, 'keyp_colors_sparks_sensitivity', skeyp_colors_sparks_sensitivity[0:-1])
 
-  skeys_pos=""
-  for i in prefs.keys_pos:
-    skeys_pos+= str(int(i[0]))+":"+str(int(i[1]))+","
-  config.set(section, 'keys_pos', skeys_pos[0:-1])
+	spercolor_sensitivity=''
+	for i in prefs.percolor_delta:
+		spercolor_sensitivity += str(round(i,2))+','
+	config.set(section, 'percolor_sensitivity', spercolor_sensitivity[0:-1])
+	config.set(section, 'use_percolor_sensitivity', str( int(prefs.use_percolor_delta) ))
 
-  s=""
-  for i in prefs.keyp_colors_alternate:
-    s+= str(int(i[0]))+":"+str(int(i[1]))+":"+str(int(i[2]))+","
-  config.set(section, 'keyp_colors_alternate', s[0:-1])
-  #
-  s=""
-  for i in prefs.keyp_colors_alternate_sensitivity:
-    s+= str(int(i))+","
-  config.set(section, 'keyp_colors_alternate_sensitivity', s[0:-1])
+	skeys_pos=''
+	for i in prefs.keys_pos:
+		skeys_pos+= str(int(i[0]))+':'+str(int(i[1]))+','
+	config.set(section, 'keys_pos', skeys_pos[0:-1])
 
-  with open(settingsfile, 'w') as configfile:
-    config.write(configfile)
-  pass
+	s=''
+	for i in prefs.keyp_colors_alternate:
+		s+= str(int(i[0]))+':'+str(int(i[1]))+':'+str(int(i[2]))+','
+	config.set(section, 'keyp_colors_alternate', s[0:-1])
 
+	s=''
+	for i in prefs.keyp_colors_alternate_sensitivity:
+		s+= str(int(i))+','
+	config.set(section, 'keyp_colors_alternate_sensitivity', s[0:-1])
+
+	with open(settingsfile, 'w') as configfile:
+		config.write(configfile)
 
 
 
 
-def loadsettings( cfgfile ):
-  print("starting read settings...")
 
-  if not os.path.exists( cfgfile ):
-    print("cannot find settings file: "+cfgfile)
-    return
+def loadsettings(cfgfile: str) -> None:
+	print('starting read settings...')
 
-  print("reading settings from file: "+cfgfile)
-  config = ConfigParser()
-  config.read( cfgfile )
-  section = 'options'
-  if config.has_option(section, 'midi_track_name'):
-    prefs.miditrackname = config.get(section, 'midi_track_name')
-  if config.has_option(section, 'debug'):
-    prefs.debug = config.getboolean(section, 'debug')
-  if config.has_option(section, 'notes_overlap'):
-    prefs.notes_overlap = config.getboolean(section, 'notes_overlap')
-  if config.has_option(section, 'resize'):
-    prefs.resize = config.getboolean(section, 'resize')
-  if config.has_option(section, 'resize_width'):
-    prefs.resize_width = config.getint(section, 'resize_width')
-  if config.has_option(section, 'resize_height'):
-    prefs.resize_height = config.getint(section, 'resize_height')
-  if config.has_option(section, 'minimal_note_duration'):
-    prefs.minimal_duration = config.getfloat(section, 'minimal_note_duration')
-  if config.has_option(section, 'color_channel_accordance'):
-    clr_chnls = config.get(section, 'color_channel_accordance')
-  else:
-    clr_chnls = ""
+	if not os.path.exists( cfgfile ):
+		print('cannot find settings file: '+cfgfile)
+		return
 
-  if config.has_option(section, 'channel_prog_accordance'):
-    clr_chnls_prog = config.get(section, 'channel_prog_accordance')
-  else:
-    clr_chnls_prog = ""
+	print('reading settings from file: '+cfgfile)
+	config = ConfigParser()
+	config.read( cfgfile )
+	section = 'options'
+	if config.has_option(section, 'midi_track_name'):
+		prefs.miditrackname = config.get(section, 'midi_track_name')
+	if config.has_option(section, 'debug'):
+		prefs.debug = config.getboolean(section, 'debug')
+	if config.has_option(section, 'notes_overlap'):
+		prefs.notes_overlap = config.getboolean(section, 'notes_overlap')
+	if config.has_option(section, 'resize'):
+		prefs.resize = config.getboolean(section, 'resize')
+	if config.has_option(section, 'resize_width'):
+		prefs.resize_width = config.getint(section, 'resize_width')
+	if config.has_option(section, 'resize_height'):
+		prefs.resize_height = config.getint(section, 'resize_height')
+	if config.has_option(section, 'minimal_note_duration'):
+		prefs.minimal_duration = config.getfloat(section, 'minimal_note_duration')
+	if config.has_option(section, 'color_channel_accordance'):
+		clr_chnls = config.get(section, 'color_channel_accordance')
+	else:
+		clr_chnls = ''
 
-  if config.has_option(section, 'ignore_notes_with_minimal_duration'):
-    prefs.ignore_minimal_duration = config.getboolean(section, 'ignore_notes_with_minimal_duration')
-  if config.has_option(section, 'notes_overlap'):
-    prefs.notes_overlap = config.getboolean(section, 'notes_overlap')
-  if config.has_option(section, 'sensitivity'):
-    prefs.keyp_delta = config.getint(section, 'sensitivity')
-  if config.has_option(section, 'octave'):
-    prefs.octave = config.getint(section, 'octave')
-  #
-  if config.has_option(section, 'midi_file_format'):
-    midi_file_format = config.getint(section, 'midi_file_format')
-    print(midi_file_format)
-  if config.has_option(section, 'output_midi_tempo'):
-    prefs.tempo = config.getint(section, 'output_midi_tempo')
-  if config.has_option(section, 'frame_start'):
-    prefs.startframe = config.getint(section, 'frame_start')
-  if config.has_option(section, 'blackkey_relative_position'):
-    prefs.blackkey_relative_position = config.getfloat(section, 'blackkey_relative_position')
+	if config.has_option(section, 'channel_prog_accordance'):
+		clr_chnls_prog = config.get(section, 'channel_prog_accordance')
+	else:
+		clr_chnls_prog = ''
 
-  # Sparks
-  if config.has_option(section, 'keyp_spark_y_pos'):
-    prefs.keyp_spark_y_pos = config.getint(section, 'keyp_spark_y_pos')
+	if config.has_option(section, 'ignore_notes_with_minimal_duration'):
+		prefs.ignore_minimal_duration = config.getboolean(section, 'ignore_notes_with_minimal_duration')
+	if config.has_option(section, 'notes_overlap'):
+		prefs.notes_overlap = config.getboolean(section, 'notes_overlap')
+	if config.has_option(section, 'sensitivity'):
+		prefs.keyp_delta = config.getint(section, 'sensitivity')
+	if config.has_option(section, 'octave'):
+		prefs.octave = config.getint(section, 'octave')
 
-  if config.has_option(section, 'use_sparks'):
-    prefs.use_sparks = config.getint(section, 'use_sparks')
-  if config.has_option(section, 'use_alternate_keys'):
-    prefs.use_alternate_keys = config.getboolean(section, 'use_alternate_keys')
+	if config.has_option(section, 'midi_file_format'):
+		midi_file_format = config.getint(section, 'midi_file_format')
+		print(midi_file_format)
+	if config.has_option(section, 'output_midi_tempo'):
+		prefs.tempo = config.getint(section, 'output_midi_tempo')
+	if config.has_option(section, 'frame_start'):
+		prefs.startframe = config.getint(section, 'frame_start')
+	if config.has_option(section, 'blackkey_relative_position'):
+		prefs.blackkey_relative_position = config.getfloat(section, 'blackkey_relative_position')
 
-  if ( clr_chnls != "" ):
-    prefs.keyp_colors_channel = [ int(x) for x in clr_chnls.split(",") ]
-    print("readed color = channel", prefs.keyp_colors_channel)
+	# Sparks
+	if config.has_option(section, 'keyp_spark_y_pos'):
+		prefs.keyp_spark_y_pos = config.getint(section, 'keyp_spark_y_pos')
 
-  if ( clr_chnls_prog != "" ):
-    prefs.keyp_colors_channel_prog = [ int(x) for x in clr_chnls_prog.split(",") ]
+	if config.has_option(section, 'use_sparks'):
+		prefs.use_sparks = config.getint(section, 'use_sparks')
+	if config.has_option(section, 'use_alternate_keys'):
+		prefs.use_alternate_keys = config.getboolean(section, 'use_alternate_keys')
 
-    print("readed color channel = prog ", prefs.keyp_colors_channel_prog)
+	if ( clr_chnls != "" ):
+		prefs.keyp_colors_channel = [ int(x) for x in clr_chnls.split(',') ]
+		print('read color = channel', prefs.keyp_colors_channel)
 
-  if config.has_option(section, 'xoffset_whitekeys'):
-    prefs.xoffset_whitekeys = config.getint(section, 'xoffset_whitekeys')
-  if config.has_option(section, 'yoffset_whitekeys'):
-    prefs.yoffset_whitekeys = config.getint(section, 'yoffset_whitekeys')
-  if config.has_option(section, 'yoffset_blackkeys'):
-    prefs.yoffset_blackkeys = config.getint(section, 'yoffset_blackkeys')
-  if config.has_option(section, 'whitekey_width'):
-    prefs.whitekey_width = config.getint(section, 'whitekey_width')
+	if ( clr_chnls_prog != '' ):
+		prefs.keyp_colors_channel_prog = [ int(x) for x in clr_chnls_prog.split(',') ]
 
-  if config.has_option(section, 'keyp_colors'):
-    skeyp_colors = config.get(section, 'keyp_colors')
-    if ( skeyp_colors.strip() != "" ):
-      prefs.keyp_colors[:] = []
-      for cur in skeyp_colors.split(","):
-        c = cur.split(":")
-        prefs.keyp_colors.append( [ int(c[0]), int(c[1]),int(c[2]) ])
+		print('read color channel = prog ', prefs.keyp_colors_channel_prog)
 
-  if config.has_option(section, 'keyp_colors_sparks_sensitivity'):
-    skeyp_colors_sparks_sensitivity = config.get(section, 'keyp_colors_sparks_sensitivity')
-    if ( skeyp_colors_sparks_sensitivity.strip() != "" ):
-      prefs.keyp_colors_sparks_sensitivity[:] = []
-      for cur in skeyp_colors_sparks_sensitivity.split(","):
-        prefs.keyp_colors_sparks_sensitivity.append( float(cur) )
+	if config.has_option(section, 'xoffset_whitekeys'):
+		prefs.xoffset_whitekeys = config.getint(section, 'xoffset_whitekeys')
+	if config.has_option(section, 'yoffset_whitekeys'):
+		prefs.yoffset_whitekeys = config.getint(section, 'yoffset_whitekeys')
+	if config.has_option(section, 'yoffset_blackkeys'):
+		prefs.yoffset_blackkeys = config.getint(section, 'yoffset_blackkeys')
+	if config.has_option(section, 'whitekey_width'):
+		prefs.whitekey_width = config.getint(section, 'whitekey_width')
 
+	if config.has_option(section, 'keyp_colors'):
+		skeyp_colors = config.get(section, 'keyp_colors')
+		if ( skeyp_colors.strip() != '' ):
+			prefs.keyp_colors[:] = []
+			for cur in skeyp_colors.split(','):
+				c = cur.split(':')
+				prefs.keyp_colors.append( [ int(c[0]), int(c[1]),int(c[2]) ])
 
-  if config.has_option(section, 'keys_pos'):
-    skeys_pos = config.get(section, 'keys_pos')
-    if ( skeys_pos.strip() != "" ):
-      prefs.keys_pos = []
-      for cur in skeys_pos.split(","):
-        c = cur.split(":")
-        prefs.keys_pos.append( [ int(c[0]), int(c[1])  ])
-      print( len(prefs.keyp_colors) )
-      print( len(prefs.keyp_colors_channel))
-
-  if config.has_option(section, 'keyp_colors_alternate'):
-    s = config.get(section, 'keyp_colors_alternate')
-    if ( s.strip() != "" ):
-      prefs.keyp_colors_alternate[:] = []
-      for cur in s.split(","):
-        c = cur.split(":")
-        print(" Append :" + str(cur))
-        prefs.keyp_colors_alternate.append( [ int(c[0]), int(c[1]),int(c[2]) ])
-  #
-  if config.has_option(section, 'keyp_colors_alternate_sensitivity'):
-    s = config.get(section, 'keyp_colors_alternate_sensitivity')
-    if ( s.strip() != "" ):
-      prefs.keyp_colors_alternate_sensitivity[:] = []
-      for cur in s.split(","):
-        prefs.keyp_colors_alternate_sensitivity.append( int(cur) )
-  if config.has_option(section, 'rollcheck'):
-    prefs.rollcheck = config.getboolean(section, 'rollcheck')
-  if config.has_option(section, 'rollcheck_priority'):
-    prefs.rollcheck_priority = config.getboolean(section, 'rollcheck_priority')
-
-  if config.has_option(section, 'use_percolor_sensitivity'):
-    prefs.use_percolor_delta = config.getboolean(section, 'use_percolor_sensitivity')
-
-  if config.has_option(section, 'percolor_sensitivity'):
-    s = config.get(section, 'percolor_sensitivity')
-    prefs.percolor_delta = [ float(x) for x in s.split(",") ]
-    print("percolor_sensitivity", prefs.percolor_delta)
-  pass
+	if config.has_option(section, 'keyp_colors_sparks_sensitivity'):
+		skeyp_colors_sparks_sensitivity = config.get(section, 'keyp_colors_sparks_sensitivity')
+		if ( skeyp_colors_sparks_sensitivity.strip() != '' ):
+			prefs.keyp_colors_sparks_sensitivity[:] = []
+			for cur in skeyp_colors_sparks_sensitivity.split(','):
+				prefs.keyp_colors_sparks_sensitivity.append( float(cur) )
 
 
-def compatibleColors(colorBtns):
-  while ( len(prefs.keyp_colors) < len(colorBtns) ):
-    print("Warning, append array keyp_colors", len(prefs.keyp_colors))
-    prefs.keyp_colors.append( [0,0,0] )
+	if config.has_option(section, 'keys_pos'):
+		skeys_pos = config.get(section, 'keys_pos')
+		if ( skeys_pos.strip() != '' ):
+			prefs.keys_pos = []
+			for cur in skeys_pos.split(','):
+				c = cur.split(':')
+				prefs.keys_pos.append( [ int(c[0]), int(c[1]) ])
+			print( len(prefs.keyp_colors) )
+			print( len(prefs.keyp_colors_channel))
 
-  while ( len(prefs.keyp_colors_channel) < len(prefs.keyp_colors) ):
-    print("Warning, append array keyp_colors_channel", len(prefs.keyp_colors_channel))
-    prefs.keyp_colors_channel.append( len(prefs.keyp_colors_channel) // 2 )
+	if config.has_option(section, 'keyp_colors_alternate'):
+		s = config.get(section, 'keyp_colors_alternate')
+		if ( s.strip() != '' ):
+			prefs.keyp_colors_alternate[:] = []
+			for cur in s.split(','):
+				c = cur.split(':')
+				print(' Append :' + str(cur))
+				prefs.keyp_colors_alternate.append( [ int(c[0]), int(c[1]),int(c[2]) ])
 
-  while ( len(prefs.keyp_colors_channel_prog) < len(prefs.keyp_colors) ):
-    print("Warning, append array keyp_colors_channel_prog", len(prefs.keyp_colors_channel_prog))
-    prefs.keyp_colors_channel_prog.append(0)
-  #
-  while len( prefs.percolor_delta ) < len(prefs.keyp_colors):
-    prefs.percolor_delta.append(0)
-  #
-  while ( len(prefs.keyp_colors_sparks_sensitivity) < len(prefs.keyp_colors) ):
-    print( 'add sparks',len(prefs.keyp_colors_sparks_sensitivity) , len(prefs.keyp_colors) )
-    prefs.keyp_colors_sparks_sensitivity.append(50)
-  print('keyp_colors:', len(prefs.keyp_colors) )
-  print('keyp_colors_channel:', len(prefs.keyp_colors_channel))
+	if config.has_option(section, 'keyp_colors_alternate_sensitivity'):
+		s = config.get(section, 'keyp_colors_alternate_sensitivity')
+		if ( s.strip() != '' ):
+			prefs.keyp_colors_alternate_sensitivity[:] = []
+			for cur in s.split(','):
+				prefs.keyp_colors_alternate_sensitivity.append( int(cur) )
+	if config.has_option(section, 'rollcheck'):
+		prefs.rollcheck = config.getboolean(section, 'rollcheck')
+	if config.has_option(section, 'rollcheck_priority'):
+		prefs.rollcheck_priority = config.getboolean(section, 'rollcheck_priority')
 
-  print('percolor_delta:', len(prefs.percolor_delta))
-  print('keyp_colors_sparks_sensitivity:', len(prefs.keyp_colors_sparks_sensitivity))
-  pass
+	if config.has_option(section, 'use_percolor_sensitivity'):
+		prefs.use_percolor_delta = config.getboolean(section, 'use_percolor_sensitivity')
+
+	if config.has_option(section, 'percolor_sensitivity'):
+		s = config.get(section, 'percolor_sensitivity')
+		prefs.percolor_delta = [ float(x) for x in s.split(',') ]
+		print('percolor_sensitivity', prefs.percolor_delta)
+
+
+def compatibleColors(colorBtns: list) -> None:
+	while ( len(prefs.keyp_colors) < len(colorBtns) ):
+		print('Warning, append array keyp_colors', len(prefs.keyp_colors))
+		prefs.keyp_colors.append( [0,0,0] )
+
+	while ( len(prefs.keyp_colors_channel) < len(prefs.keyp_colors) ):
+		print('Warning, append array keyp_colors_channel', len(prefs.keyp_colors_channel))
+		prefs.keyp_colors_channel.append( len(prefs.keyp_colors_channel) // 2 )
+
+	while ( len(prefs.keyp_colors_channel_prog) < len(prefs.keyp_colors) ):
+		print('Warning, append array keyp_colors_channel_prog', len(prefs.keyp_colors_channel_prog))
+		prefs.keyp_colors_channel_prog.append(0)
+
+	while len( prefs.percolor_delta ) < len(prefs.keyp_colors):
+		prefs.percolor_delta.append(0)
+
+	while ( len(prefs.keyp_colors_sparks_sensitivity) < len(prefs.keyp_colors) ):
+		print( 'add sparks',len(prefs.keyp_colors_sparks_sensitivity) , len(prefs.keyp_colors) )
+		prefs.keyp_colors_sparks_sensitivity.append(50)
+	print('keyp_colors:', len(prefs.keyp_colors) )
+	print('keyp_colors_channel:', len(prefs.keyp_colors_channel))
+
+	print('percolor_delta:', len(prefs.percolor_delta))
+	print('keyp_colors_sparks_sensitivity:', len(prefs.keyp_colors_sparks_sensitivity))


### PR DESCRIPTION
`v2m.py` is missing, will do that later if I get to it.

This is a refactor and also a fix taken from #52, I was already fixing the unicode issue so might as well fix the backslash.

Also fixes calling pygame tostring() with a Literal instead of boolean.

This drops Python 2.7 <-> 3.8, people needing those versions can use the version before this one, they are all End of Life.

Fixes up CI to check the currently supported Python versions.

Adds pyproject.toml which is current standard, only with the linter stuff for now.

Unifies code base to tabs and changes the code where it was problematic when indent width would differ in the view - now everyone can use their preferred code width.

Unified code base to single quotes, as that's what's mostly used.

Fixed up small end of line space issues.

Use f-strings over the old way 

Fixed readme.md recommending to run `sudo pip` which fails on all major distributions thanks to a new PEP -> venvs are necessary now.

Added return types to a lot of functions/variables, not everywhere though.

This should make maintenance and spotting issues easier - in fact a linter+LSP highlights a bunch, even after this commit.

Apologies for not splitting this into more commits, it could have used that.

I suggest Hiding Whitespace when reviewing - https://github.com/svsdval/video2midi/pull/53/files?diff=split&w=1